### PR TITLE
chore: fixing code color contrast on dark mode

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -133,6 +133,8 @@
   --vp-code-block-bg: #2a2a2a;
   --vp-code-tab-hover-text-color: var(--vp-c-text-dark-2);
   --vp-code-tab-active-text-color: var(--vp-c-text-dark-1);
+  
+  --vp-c-text-code: #e8e8e8;
 }
 
 .vp-doc h1, .vp-doc h2, .vp-doc h3, .vp-doc h4, .vp-doc h5, .vp-doc h6 {


### PR DESCRIPTION
Hello 👋 congrats on V3 launch 

This or fixes a small thing, as you can see below color contrast for `code`  blocks on dark mode 

<img width="743" alt="CleanShot 2023-02-18 at 19 43 19@2x" src="https://user-images.githubusercontent.com/43112535/219877633-32f89ece-392a-4a81-b2fa-4c48a79e8a42.png">

And here is the final look after adding the fix

![CleanShot 2023-02-18 at 19 38 43](https://user-images.githubusercontent.com/43112535/219877808-c46c9db7-d4a5-4ed2-ae1a-144ab4d60667.gif)

