### PR TITLE
fix: link to edit page

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -108,7 +108,7 @@ export default defineConfig({
       { icon: 'twitter', link: 'https://twitter.com/honojs' },
     ],
     editLink: {
-      pattern: 'https://github.com/honojs/website/edit/main:path',
+      pattern: 'https://github.com/honojs/website/edit/main/:path',
       text: 'Edit this page on GitHub',
     },
     footer: {


### PR DESCRIPTION
Currently, the link of **Edit this page on GitHub** points to the wrong endpoint (missing slash between main and file name), this PR fixes the config in `.vitepress/config.js` to point a correct endpoint.

https://user-images.githubusercontent.com/35027979/220932978-705078cc-c7de-43c3-9b92-6cb168f3c083.mp4
