### PR TITLE
fix: Use `bind` with custom fetch method

### DIFF
--- a/guides/rpc.md
+++ b/guides/rpc.md
@@ -149,7 +149,7 @@ services = [
 
 ```ts
 // src/client.ts
-const client = hc<CreateProfileType>('/', { fetch: c.env.AUTH.fetch })
+const client = hc<CreateProfileType>('/', { fetch: c.env.AUTH.fetch.bind(c.env.AUTH) })
 ```
 
 ## Infer


### PR DESCRIPTION
When passing the custom fetch method for a Cloudflare Service binding, it is necessary to use `bind` since without it an `Illegal Innvocation` Error is thrown.

