### PR TITLE
Update: 4th step path to index.ts

### DIFF
--- a/getting-started/bun.md
+++ b/getting-started/bun.md
@@ -43,7 +43,7 @@ export default {
 Run the command.
 
 ```ts
-bun run --hot index.ts
+bun run --hot src/index.ts
 ```
 
 Then, access `http://localhost:3000` in your browser.


### PR DESCRIPTION
Unless the user remembers to cd into the `src` folder, executing the 4th command in the instructions will result in a `error: missing script "index.ts"` since the user is in the wrong path.

Minor fix, but makes the experience for first timers a little bit more straightforward & less error-prone :)