### PR TITLE
Changed Interface to Type

### DIFF
--- a/guides/examples.md
+++ b/guides/examples.md
@@ -18,7 +18,7 @@ app.get('/', (c) => c.text('Pretty Blog API'))
 app.use('*', prettyJSON())
 app.notFound((c) => c.json({ message: 'Not Found', ok: false }, 404))
 
-export interface Bindings {
+type Bindings = {
   USERNAME: string
   PASSWORD: string
 }


### PR DESCRIPTION
It appears the above example did not work until changing the interface for Bindings into a Type instead.