### PR TITLE
Add some explanation to AWS Lambda

### DIFF
--- a/api/adapter.md
+++ b/api/adapter.md
@@ -17,6 +17,7 @@ app.get('/env', (c) => {
 
 Supported runtimes:
 
+- AWS Lambda
 - Cloudflare Workers
 - Deno
 - Bun

--- a/api/adapter.md
+++ b/api/adapter.md
@@ -17,10 +17,10 @@ app.get('/env', (c) => {
 
 Supported runtimes:
 
-- AWS Lambda
 - Cloudflare Workers
 - Deno
 - Bun
 - Lagon
 - Node.js
 - Vercel
+- AWS Lambda

--- a/getting-started/aws-lambda.md
+++ b/getting-started/aws-lambda.md
@@ -71,3 +71,17 @@ Finally, run the command to deploy:
 ```
 cdk deploy
 ```
+
+## Serve Binary data
+
+Hono supports binary data as a response.
+In Lambda, base64 encoding is required to return binary data.
+Once binary type is set to `Content-Type` header, Hono automatically encode data.
+
+```ts
+app.get('/binary', async (c) => {
+    c.status(200);
+    c.header('Content-Type', 'image/png'); // means binary data
+    return c.body(buffer); // supports `ArrayBufferLike` type, encoded to base64.
+});
+```


### PR DESCRIPTION
https://github.com/honojs/hono/releases/tag/v3.2.5

In Hono v3.2.5, AWS Lambda adaptor is improved in binary response.
Added some explanation about binary response.