### PR TITLE
Update cookie.md after Hono `3.2.7` release

### DIFF
--- a/middleware/builtin/cookie.md
+++ b/middleware/builtin/cookie.md
@@ -1,6 +1,6 @@
 # Cookie Middleware
 
-This middleware for parsing Cookies.
+This middleware for setting, parsing and deleting Cookies.
 
 ## Import
 
@@ -8,12 +8,12 @@ This middleware for parsing Cookies.
 
 ```ts [npm]
 import { Hono } from 'hono'
-import { getCookie, setCookie } from 'hono/cookie'
+import { getCookie, setCookie, deleteCookie } from 'hono/cookie'
 ```
 
 ```ts [Deno]
 import { Hono } from 'https://deno.land/x/hono/mod.ts'
-import { getCookie, setCookie } from 'https://deno.land/x/hono/middleware.ts'
+import { getCookie, setCookie, deleteCookie } from 'https://deno.land/x/hono/middleware.ts'
 ```
 
 :::
@@ -27,6 +27,7 @@ app.get('/cookie', (c) => {
   const yummyCookie = getCookie(c, 'yummy_cookie')
   // ...
   setCookie(c, 'delicious_cookie', 'macha')
+  deleteCookie(c, 'delicious_cookie')
   //
 })
 ```
@@ -55,5 +56,21 @@ setCookie('great_cookie', 'banana', {
   maxAge: 1000,
   expires: new Date(Date.UTC(2000, 11, 24, 10, 30, 59, 900)),
   sameSite: 'Strict',
+})
+```
+
+### `deleteCookie`
+
+- `path`: string
+- `secure`: boolean
+- `domain`: string
+
+Example:
+
+```ts
+deleteCookie(c, 'banana', {
+  path: '/',
+  secure: true,
+  domain: 'example.com',
 })
 ```


### PR DESCRIPTION
After Hono `3.2.7` release, I've updated `cookie` docs with `deleteCookie`.