### PR TITLE
Opt for "bun create" in the bun guide

### DIFF
--- a/getting-started/bun.md
+++ b/getting-started/bun.md
@@ -9,10 +9,10 @@ To install `bun` command, follow the instruction in [the official web site](http
 
 ## 2. Setup
 
-A starter for Bun is available. Start your project with "create-hono" command.
+A starter for Bun is available. Start your project with "bun create" command.
 
 ```
-npm create hono@latest my-app
+bun create hono my-app
 ```
 
 Move into my-app and install the dependencies.


### PR DESCRIPTION
Use [`bun create`](https://bun.sh/docs/templates#bun-create) with the [hono template](https://github.com/bun-community/create-templates/tree/main/hono), because most people creating a project using bun will opt for the `bun` package manager over `npm`