### PR TITLE
Update assert link

### DIFF
--- a/getting-started/deno.md
+++ b/getting-started/deno.md
@@ -116,7 +116,7 @@ You can write with `Deno.test` and use `assert` or `assertEquals` from the stand
 
 ```ts
 import { Hono } from 'https://deno.land/x/hono/mod.ts'
-import { assertEquals } from 'https://deno.land/std/testing/asserts.ts'
+import { assertEquals } from 'https://deno.land/std/assert/mod.ts'
 
 Deno.test('Hello World', async () => {
   const app = new Hono()


### PR DESCRIPTION
the previously used import is deprecated 
<img width="652" alt="image" src="https://github.com/honojs/website/assets/4562878/f0655a75-8f9b-4d59-bb84-52a9aea971ba">

