### PR TITLE
Fix: replace app.get with app.use in Secure Headers middleware

### DIFF
--- a/middleware/builtin/secure-headers.md
+++ b/middleware/builtin/secure-headers.md
@@ -24,14 +24,14 @@ You can use the optimal settings by default.
 
 ```ts
 const app = new Hono()
-app.get('*', secureHeaders())
+app.use('*', secureHeaders())
 ```
 
 You can suppress unnecessary headers by setting them to false.
 
 ```ts
 const app = new Hono()
-app.get(
+app.use(
   '*',
   secureHeaders({
     xFrameOptions: false,
@@ -44,7 +44,7 @@ You can override default header values using a string.
 
 ```ts
 const app = new Hono()
-app.get(
+app.use(
   '*',
   secureHeaders({
     strictTransportSecurity: 'max-age=63072000; includeSubDomains; preload',


### PR DESCRIPTION
Currently the [Secure Headers page](https://hono.dev/middleware/builtin/secure-headers) contains some code examples that use `app.get` instead of correct method for the middleware — `.use`.

This PR replaces all `.get("*")` misuses with `.use("*")`.