### PR TITLE
docs: Add usage of jwt with payload in hono/jwt middleware

### DIFF
--- a/middleware/builtin/jwt.md
+++ b/middleware/builtin/jwt.md
@@ -36,6 +36,24 @@ app.get('/auth/page', (c) => {
 })
 ```
 
+Get payload:
+
+```js
+const app = new Hono()
+
+app.use(
+  '/auth/*',
+  jwt({
+    secret: 'it-is-very-secret',
+  })
+)
+
+app.get('/auth/page', (c) => {
+  const payload = c.get('jwtPayload')
+  return c.json(payload) // eg: { "sub": "1234567890", "name": "John Doe", "iat": 1516239022 }
+})
+```
+
 ## Options
 
 - `secret`: string - _required_


### PR DESCRIPTION
Hi, @yusukebe 
I added this because when using the hono/jwt middleware, I didn't realize that payload was available until I went to the source code.
If you like it, I hope you'll MERGE it.

---

BTW, when using jwt on the edge, the only library I could find was https://github.com/tsndr/cloudflare-worker-jwt. are there any plans to release utils/jwt as a package like @hono/jwt?