### PR TITLE
docs: Add all helper links

### DIFF
--- a/guides/helpers.md
+++ b/guides/helpers.md
@@ -19,6 +19,8 @@ app.get('/cookie', (c) => {
 
 ## Available Helpers
 
+- [Adapter](/helpers/adapter)
 - [Cookie](/helpers/cookie)
 - [html](/helpers/html)
-- [Adapter](/helpers/adapter)
+- [JWT](/helpers/jwt)
+- [Testing](/helpers/testing)


### PR DESCRIPTION
In the helper guide there is a link to all the helpers, however, a few were missing due to recent updates