### PR TITLE
changed example for /api/routing#including-slashes

### DIFF
--- a/api/routing.md
+++ b/api/routing.md
@@ -64,7 +64,7 @@ app.get('/post/:date{[0-9]+}/:title{[a-z]+}', (c) => {
 ## Including slashes
 
 ```ts
-app.get('/posts/:filename{.+.png$}', (c) => {
+app.get('/posts/:filename{.+\\.png$}', (c) => {
   //...
 })
 ```


### PR DESCRIPTION
This variant is more correct for routes which ends `.png`