### PR TITLE
Add documentation for deploying Hono apps to endpts

### DIFF
--- a/concepts/web-standard.md
+++ b/concepts/web-standard.md
@@ -26,6 +26,7 @@ In addition, we have a Node.js adapter. Hono runs on these runtimes:
 - AWS Lambda
 - Node.js
 - Vercel (edge-light)
+- endpts
 
 It also works on Netlify and other platforms.
 The same code runs on all platforms.

--- a/getting-started/basic.md
+++ b/getting-started/basic.md
@@ -25,6 +25,7 @@ Let's select Cloudflare Workers for this example.
     nextjs
     nodejs
     vercel
+    endpts
 ```
 
 The template will be pulled into `my-app`, so go to it and install the dependencies.

--- a/getting-started/endpts.md
+++ b/getting-started/endpts.md
@@ -1,0 +1,58 @@
+# endpts
+
+[endpts](https://endpts.io/) is a platform to seamlessly build and deploy APIs powered by Node.js serverless functions. The endpts development environment supports TypeScript out of the box, hot reloading, and bundling.
+
+You can run your Hono application with access to the entire NPM ecosystem and Node.js APIs.
+
+## 1. Setup
+
+A starter template for endpts is available. Start your project with "create-hono" command:
+
+```
+npm create hono@latest my-app
+```
+
+Move to `my-app` and install the dependencies:
+
+```
+cd my-app
+npm i
+```
+
+## 2. Hello World
+
+The `routes/index.ts` contains a simple Hono application:
+
+```ts
+// routes/index.ts
+import { Hono } from 'hono'
+const app = new Hono()
+
+app.get('/', (c) => c.text('Hello Hono!'))
+
+export default {
+  handler: app.fetch,
+}
+```
+
+endpts Functions use Web Standard APIs making them compatible with Hono by assigning `app.fetch` to the `handler`.
+
+The `routes/` directory is a special directory that endpts automatically scans to register your applications routes. You can read more about the project structure in the [endpts Documentation](https://endpts.io/docs/core-concepts/serverless-functions).
+
+## 3. Run
+
+Run the command.
+
+```ts
+npm run dev
+```
+
+Then, visit `http://localhost:3000` in your browser or use curl:
+
+```shell
+curl http://localhost:3000
+```
+
+## 4. Deploy
+
+You can deploy your application to endpts via the [endpts Dashboard](https://dashboard.endpts.io/). You can connect your GitHub account to automatically deploy your application on every push.

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ head:
       'meta',
       {
         property: 'og:description',
-        content: 'Hono is a small, simple, and ultrafast web framework for the Edges. It works on Cloudflare Workers, Fastly Compute@Edge, Deno, Bun, Vercel, Netlify, Lagon, AWS Lambda, Lambda@Edge, and Node.js. Fast, but not only fast.',
+        content: 'Hono is a small, simple, and ultrafast web framework for the Edges. It works on Cloudflare Workers, Fastly Compute@Edge, Deno, Bun, Vercel, Netlify, Lagon, endpts, AWS Lambda, Lambda@Edge, and Node.js. Fast, but not only fast.',
       },
     ]
 ---
@@ -14,7 +14,7 @@ head:
 # Hono
 
 Hono - _**\[炎\] means flame🔥 in Japanese**_ - is a small, simple, and ultrafast web framework for the Edges.
-It works on any JavaScript runtime: Cloudflare Workers, Fastly Compute@Edge, Deno, Bun, Vercel, Netlify, Lagon, AWS Lambda, Lambda@Edge, and Node.js.
+It works on any JavaScript runtime: Cloudflare Workers, Fastly Compute@Edge, Deno, Bun, Vercel, Netlify, Lagon, endpts, AWS Lambda, Lambda@Edge, and Node.js.
 
 Fast, but not only fast.
 
@@ -127,6 +127,7 @@ Thanks to the use of the **Web Standard API**, Hono works on a lot of platforms.
 - Bun
 - Lagon
 - Vercel
+- endpts
 - AWS Lambda
 - Lambda@Edge
 - Others


### PR DESCRIPTION
This PR adds instructions to assist users to deploy their Hono apps to [endpts](https://endpts.io/).

A PR containing the starter template was also created: https://github.com/honojs/starter/pull/11