### PR TITLE
Update vercel.md

### DIFF
--- a/getting-started/vercel.md
+++ b/getting-started/vercel.md
@@ -25,7 +25,7 @@ npm i
 
 ## 2. Hello World
 
-If you use the App Router, Edit `app/api/[...route]/route.ts`.
+If you use the App Router, Edit `app/api/[[...route]]/route.ts`.
 
 ```ts
 import { Hono } from 'hono'
@@ -46,7 +46,7 @@ app.get('/hello', (c) => {
 export const GET = handle(app)
 ```
 
-If you use the Pages Router, Edit `pages/api/[...route].ts`.
+If you use the Pages Router, Edit `pages/api/[[...route]].ts`.
 
 ```ts
 import { Hono } from 'hono'


### PR DESCRIPTION
If I try to do a request to a `/` route, i revice a 404 error

Example:
```ts
import { Hono } from 'hono'
import { handle } from 'hono/vercel'

export const runtime = 'edge';

const app = new Hono().basePath("/api")

app.get('/', (c) => {
    return c.json({
        success: true,
        data: {}
    });
})

app.notFound((c) => {
    return c.text('Custom 404 Message', 404)
 })

export const GET = handle(app)
```

This above example have some upgrade from the default example on hono docs page due some warning recived in app console running `next dev`.