### PR TITLE
Update vercel.md

### DIFF
--- a/getting-started/vercel.md
+++ b/getting-started/vercel.md
@@ -25,7 +25,7 @@ npm i
 
 ## 2. Hello World
 
-If you use the App Router, Edit `app/api/[...route]/route.ts`.
+If you use the App Router, Edit `app/api/[[...route]]/route.ts`.
 
 ```ts
 import { Hono } from 'hono'
@@ -46,7 +46,7 @@ app.get('/hello', (c) => {
 export const GET = handle(app)
 ```
 
-If you use the Pages Router, Edit `pages/api/[...route].ts`.
+If you use the Pages Router, Edit `pages/api/[[...route]].ts`.
 
 ```ts
 import { Hono } from 'hono'

--- a/getting-started/vercel.md
+++ b/getting-started/vercel.md
@@ -31,9 +31,7 @@ If you use the App Router, Edit `app/api/[[...route]]/route.ts`.
 import { Hono } from 'hono'
 import { handle } from 'hono/vercel'
 
-export const config = {
-  runtime: 'edge',
-}
+export const runtime = 'edge';
 
 const app = new Hono().basePath("/api")
 
@@ -52,9 +50,7 @@ If you use the Pages Router, Edit `pages/api/[[...route]].ts`.
 import { Hono } from 'hono'
 import { handle } from 'hono/vercel'
 
-export const config = {
-  runtime: 'edge',
-}
+export const runtime = 'edge';
 
 const app = new Hono().basePath("/api")
 
@@ -64,7 +60,7 @@ app.get('/hello', (c) => {
   })
 })
 
-export default handle(app)
+export const GET = handle(app)
 ```
 
 ## 3. Run
@@ -96,6 +92,8 @@ Next, you can utilize the `handle` function imported from `@hono/node-server/ver
 ```ts
 import { Hono } from 'hono'
 import { handle } from '@hono/node-server/vercel'
+
+
 
 const app = new Hono().basePath('/api')
 


### PR DESCRIPTION
If I try to do a request to a `/` route, i revice a 404 error, in this PR I've updated the docs using the [Next.JS Catch-all Segment](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#optional-catch-all-segments)

Example:
```ts
import { Hono } from 'hono'
import { handle } from 'hono/vercel'

export const runtime = 'edge';

const app = new Hono().basePath("/api")

app.get('/', (c) => {
    return c.json({
        success: true,
        data: {}
    });
})

app.notFound((c) => {
    return c.text('Custom 404 Message', 404)
 })

export const GET = handle(app)
```

Other error:
```
 ⚠ Page config in <path>/route.ts is deprecated. Replace `export const config=…` with the following:
  - `export const runtime = "edge"`
```

This above example have some edit from the default example on hono docs page due some warning received in app console running `next dev`.