### PR TITLE
docs(getting-started): Update Next.js runtime config export

### DIFF
--- a/getting-started/vercel.md
+++ b/getting-started/vercel.md
@@ -31,11 +31,9 @@ If you use the App Router, Edit `app/api/[...route]/route.ts`.
 import { Hono } from 'hono'
 import { handle } from 'hono/vercel'
 
-export const config = {
-  runtime: 'edge',
-}
+export const runtime = 'edge';
 
-const app = new Hono().basePath("/api")
+const app = new Hono().basePath('/api')
 
 app.get('/hello', (c) => {
   return c.json({


### PR DESCRIPTION
The default Next.js app directory template is deprecated. If you use the currently provided code, you see this warning in the console:

```
 ⚠ Page config in /Users/anandchowdhary/Downloads/1q4/app/api/[...route]/route.ts is deprecated. Replace `export const config=…` with the following:
  - `export const runtime = "edge"`
Visit https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config for more information.
```

It is recommended to change the following:

```ts
export const config = {
  runtime: "edge",
};
```

to this:

```ts
export const config = {
  runtime: "edge",
};
```

Relevant docs: [Route Segment Config](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config)