### PR TITLE
Fix Deno's links

### DIFF
--- a/getting-started/deno.md
+++ b/getting-started/deno.md
@@ -1,6 +1,6 @@
 # Deno
 
-[Deno](https://deno.land/) is a JavaScript runtime built on V8. It's not Node.js.
+[Deno](https://deno.com/) is a JavaScript runtime built on V8. It's not Node.js.
 Hono also works on Deno.
 
 You can use Hono, write the code with TypeScript, run the application with the `deno` command, and deploy it to "Deno Deploy".
@@ -8,7 +8,7 @@ You can use Hono, write the code with TypeScript, run the application with the `
 ## 1. Install Deno
 
 First, install `deno` command.
-Please refer to [the official document](https://deno.land/manual/getting_started/installation).
+Please refer to [the official document](https://docs.deno.com/runtime/manual/getting_started/installation).
 
 ## 2. Setup
 
@@ -107,7 +107,7 @@ app.get(
 Deno Deploy is an edge runtime platform for Deno.
 We can publish the application world widely on Deno Deploy.
 
-Hono also supports Deno Deploy. Please refer to [the official document](https://deno.com).
+Hono also supports Deno Deploy. Please refer to [the official document](https://docs.deno.com/deploy/manual/).
 
 ## Testing
 

--- a/index.md
+++ b/index.md
@@ -61,7 +61,7 @@ Here are some examples of use-cases.
 | [cdnjs API Server](https://cdnjs.com/api)       | Cloudflare Workers  | A free and open-source CDN service. _Hono is used for their API services_.                |
 | [Polyfill.io](https://www.polyfill.io/v3/)      | Fastly Compute@Edge | A CDN service that provides necessary browser polyfills. _Hono is used as a core server_. |
 | [Ultra](https://ultrajs.dev)                    | Deno                | A React/Deno framework. _Hono is used for the internal server_.                           |
-| [Deno Benchmarks](https://deno.land/benchmarks) | Deno                | A secure TypeScript runtime built on V8. _Hono is used for benchmarking_.                 |
+| [Deno Benchmarks](https://deno.com/benchmarks) | Deno                | A secure TypeScript runtime built on V8. _Hono is used for benchmarking_.                 |
 | [Cloudflare Blog](https://blog.cloudflare.com)  | Cloudflare Workers  | _Some applications featured in the articles use Hono_.                                    |
 
 And the following.


### PR DESCRIPTION
 `deno.land` redirect to `deno.com` in basically.
So I changed `deno.land` to `deno.com`.
And I changed the links to the correct docs.