### PR TITLE
add cloudflare workers types install guide using yarn, pnpm, bun

### DIFF
--- a/getting-started/cloudflare-workers.md
+++ b/getting-started/cloudflare-workers.md
@@ -202,9 +202,25 @@ app.get(
 
 You have to install `@cloudflare/workers-types` if you want to have workers types.
 
-```
+::: code-group
+
+```txt [npm]
 npm i --save-dev @cloudflare/workers-types
 ```
+
+```txt [yarn]
+yarn add -D @cloudflare/workers-types
+```
+
+```txt [pnpm]
+pnpm add -D @cloudflare/workers-types
+```
+
+```txt [bun]
+bun add --dev @cloudflare/workers-types
+```
+
+:::
 
 ## Testing
 


### PR DESCRIPTION
in the https://hono.dev/getting-started/cloudflare-workers#types the docs showing workers types with npm package manager, but not showing yarn, pnpm, bun. 
so I added install manual.

