### PR TITLE
docs: add `@scalar/hono-api-reference` to list of third-party middleware

### DIFF
--- a/middleware/third-party.md
+++ b/middleware/third-party.md
@@ -16,4 +16,5 @@ Most of this middleware leverages external libraries.
 - [Zod OpenAPI](https://github.com/honojs/middleware/tree/main/packages/zod-openapi)
 - [Clerk Auth](https://github.com/honojs/middleware/tree/main/packages/clerk-auth)
 - [Swagger UI](https://github.com/honojs/middleware/tree/main/packages/swagger-ui)
+- [Scalar API Reference](https://github.com/scalar/scalar/tree/main/packages/hono-api-reference)
 - [esbuild Transpiler](https://github.com/honojs/middleware/tree/main/packages/esbuild-transpiler)


### PR DESCRIPTION
This PR adds [`@scalar/hono-api-reference`](https://github.com/scalar/scalar/tree/main/packages/hono-api-reference) to the list of third-party middleware.

The middleware takes an URL to a OpenAPI/Swagger spec and renders a beautiful API reference (like Swagger UI, but doesn’t look like it’s 2011).

It comes with a Hono custom theme and some other predefined themes:

**Example**
```ts
import { apiReference } from '@scalar/hono-api-reference'

// Create a Swagger file
app.doc('/swagger.json', {
  info: {
    title: 'Example',
    description:
      'The `@scalar/hono-api-reference` middleware renders a beautiful API reference based on your OpenAPI specification.',
    version: 'v1',
  },
  openapi: '3.1.0',
})

// Load the middleware
app.get(
  '/docs',
  apiReference({
    theme: 'purple',
    spec: {
      url: '/swagger.json',
    },
  }),
)
```