### PR TITLE
Add experimental badges

### DIFF
--- a/api/context.md
+++ b/api/context.md
@@ -204,7 +204,7 @@ app.get('/echo', echoMiddleware, (c) => {
 })
 ```
 
-## render() / setRenderer()
+## render() / setRenderer() <Badge style="vertical-align: middle;" type="warning" text="Experimental" />
 
 You can set a layout using `c.setRenderer()` within a custom middleware.
 

--- a/guides/jsx.md
+++ b/guides/jsx.md
@@ -223,7 +223,7 @@ app.get('/', (c) => {
 })
 ```
 
-## Suspense
+## Suspense <Badge style="vertical-align: middle;" type="warning" text="Experimental" />
 
 The React-like `Suspense` feature is available.
 If you wrap the async component with `Suspense`, the content in the fallback will be rendered first, and once the Promise is resolved, the awaited content will be displayed.


### PR DESCRIPTION
Several methods in the Hono codebase are marked with the JSDoc annotation `@experimental`. However, there is no indication on the documentation website of which methods or features are experimental.

This pull request adds badges to feature sections that denote they are currently experimental.

> [!NOTE]
> It would probably be even better to include a note inside each section explaining the intent for if/when each API will stabilize, but I'm not familiar with the plan for these APIs so I didn't include notes like that.

### Screenshots

![CleanShot 2023-11-14 at 09 25 07@2x](https://github.com/honojs/website/assets/7614039/cd87d429-3fd6-4439-8ac7-3391a5470ada)

![CleanShot 2023-11-14 at 09 24 33@2x](https://github.com/honojs/website/assets/7614039/9ffa7ec8-8347-4d34-9d5a-8b3e0604da1f)
