### PR TITLE
update `hono/tiny` size

### DIFF
--- a/concepts/routers.md
+++ b/concepts/routers.md
@@ -83,14 +83,11 @@ For situations like Fastly Compute, it's better to use LinearRouter with the `ho
 
 While Hono is already compact, if you need to make it even smaller for an environment with limited resources, you can use PatternRouter.
 
-An application using only PatternRouter is under 12KB in size.
+An application using only PatternRouter is under 15KB in size.
 
 ```
-$ npx wrangler dev --minify ./src/index.ts
- ⛅️ wrangler 2.20.0
---------------------
-⬣ Listening at http://0.0.0.0:8787
-- http://127.0.0.1:8787
-- http://192.168.128.165:8787
-Total Upload: 11.47 KiB / gzip: 4.34 KiB
+$ npx wrangler deploy --minify ./src/index.ts
+ ⛅️ wrangler 3.20.0
+-------------------
+Total Upload: 14.68 KiB / gzip: 5.38 KiB
 ```

--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ hero:
 features:
   - icon: 🚀
     title: Ultrafast & Lightweight
-    details: The router RegExpRouter is really fast. The hono/tiny preset is under 12kB. Using only Web Standard APIs.
+    details: The router RegExpRouter is really fast. The hono/tiny preset is under 14kB. Using only Web Standard APIs.
   - icon: 🌍
     title: Multi-runtime
     details: Works on Cloudflare, Fastly, Deno, Bun, Lagon, AWS, or Node.js. The same code runs on all platforms.

--- a/top.md
+++ b/top.md
@@ -50,7 +50,7 @@ deno run -A npm:create-hono
 ## Features
 
 - **Ultrafast** 🚀 - The router `RegExpRouter` is really fast. Not using linear loops. Fast.
-- **Lightweight** 🪶 - The `hono/tiny` preset is under 12kB. Hono has zero dependencies and uses only the Web Standard API.
+- **Lightweight** 🪶 - The `hono/tiny` preset is under 14kB. Hono has zero dependencies and uses only the Web Standard API.
 - **Multi-runtime** 🌍 - Works on Cloudflare Workers, Fastly Compute, Deno, Bun, Lagon, AWS Lambda, or Node.js. The same code runs on all platforms.
 - **Batteries Included** 🔋 - Hono has built-in middleware, custom middleware, third-party middleware, and helpers. Batteries included.
 - **Delightful DX** 😃 - Super clean APIs. First-class TypeScript support. Now, we've got "Types".
@@ -106,7 +106,7 @@ See [more benchmarks](/concepts/benchmarks).
 
 ## Lightweight
 
-**Hono is so small**. With the `hono/tiny` preset, its size is **under 12KB** when minified. There are many middleware and adapters, but they are bundled only when used. For context, the size of Express is 572KB.
+**Hono is so small**. With the `hono/tiny` preset, its size is **under 14KB** when minified. There are many middleware and adapters, but they are bundled only when used. For context, the size of Express is 572KB.
 
 ```
 $ npx wrangler dev --minify ./src/index.ts


### PR DESCRIPTION
Update `hono/tiny` size and the application size.
The app was created by `create-hono` command and replaced `hono` with `hono/tiny`.
### Related
https://github.com/honojs/hono/pull/1809