### PR TITLE
Resolve Cache API Issue on Deno Deploy

### DIFF
--- a/middleware/builtin/cache.md
+++ b/middleware/builtin/cache.md
@@ -2,7 +2,11 @@
 
 The Cache middleware uses the Web Standard's [Cache API](https://developer.mozilla.org/en-US/docs/Web/API/Cache). It caches a given response according to the `Cache-Control` headers.
 
-The Cache middleware currently supports Cloudflare Workers projects using custom domains and Deno projects using [Deno 1.26+](https://github.com/denoland/deno/releases/tag/v1.26.0), but doesn't supports Lagon. See [Usage](#usage) below for instructions on each platform.
+The Cache middleware currently supports Cloudflare Workers projects using custom domains and Deno projects using [Deno 1.26+](https://github.com/denoland/deno/releases/tag/v1.26.0), but doesn't supports Lagon. 
+
+Please be aware that the Cache API is not currently supported by Deno Deploy. The `caches` variable, which is part of the Cache API, may not be available in the Deno Deploy environment.
+
+See [Usage](#usage) below for instructions on each platform.
 
 ## Import
 


### PR DESCRIPTION
@yusukebe This pull request addresses issue #184, which is related to the Cache API not being supported on Deno Deploy. I have added a note to the documentation, clearly specifying that the Cache API is currently unsupported by Deno Deploy.