### PR TITLE
Fix typo in basic.md

### DIFF
--- a/getting-started/basic.md
+++ b/getting-started/basic.md
@@ -220,7 +220,7 @@ app.use(
 )
 
 app.get('/admin', (c) => {
-  return c.text('Your are authorized!')
+  return c.text('You are authorized!')
 })
 ```
 


### PR DESCRIPTION
Fix typo, your -> you in `getting-started/basic.md`