### PR TITLE
Add env section to testing guide

### DIFF
--- a/guides/testing.md
+++ b/guides/testing.md
@@ -74,3 +74,18 @@ test('POST /posts', async () => {
 ```
 
 In this way, you can test it as like an End-to-End.
+
+## Env
+
+To set `c.env` for testing, you can pass it as the 3rd parameter to `app.request`. This is useful for mocking values like [Cloudflare Workers Bindings](https://hono.dev/getting-started/cloudflare-workers#bindings):
+
+```ts
+const MOCK_ENV = {
+  API_HOST: 'example.com',
+  DB: { prepare: () => { /* mocked D1 */ } },
+}
+
+test('GET /posts', async () => {
+  const res = await app.request('/posts', {}, MOCK_ENV)
+})
+```


### PR DESCRIPTION
## Suggestion

I had a little bit of trouble getting a good testing setup for Hono + Cloudflare Workers, because they use so many `env` vars. I read this testing guide initially, but as it gave no hints to env, I tried a bunch of different solutions (even including some complicated Vitest code replacement) before I realized this was so easy to pull off.

Open to feedback/suggestions if there’s a better way to do this (i.e. if there’s a better recommended way), but I found this a relatively simple, flexible setup for my own testing.