### PR TITLE
Fix next.js pages router example

### DIFF
--- a/getting-started/vercel.md
+++ b/getting-started/vercel.md
@@ -101,7 +101,7 @@ app.get('/hello', (c) => {
   })
 })
 
-export default handle(app);
+export default handle(app)
 ```
 
 ## 3. Run

--- a/getting-started/vercel.md
+++ b/getting-started/vercel.md
@@ -89,7 +89,9 @@ If you use the Pages Router, Edit `pages/api/[[...route]].ts`.
 import { Hono } from 'hono'
 import { handle } from 'hono/vercel'
 
-export const runtime = 'edge';
+export const config = {
+  runtime: "edge",
+};
 
 const app = new Hono().basePath("/api")
 
@@ -99,7 +101,7 @@ app.get('/hello', (c) => {
   })
 })
 
-export const GET = handle(app)
+export default handle(app);
 ```
 
 ## 3. Run


### PR DESCRIPTION
Noticed the example for the Next.js pages router used the app router syntax.

1. For edge functions in the page router, export a `config` variable, not `runtime` (https://vercel.com/docs/functions/edge-functions/edge-functions-api)
2. Route handlers are not supported in the pages router