### PR TITLE
docs: update custom context renderer type

### DIFF
--- a/middleware/builtin/jsx-renderer.md
+++ b/middleware/builtin/jsx-renderer.md
@@ -169,7 +169,7 @@ By defining `ContextRenderer` as shown below, you can pass additional content to
 ```tsx
 declare module 'hono' {
   interface ContextRenderer {
-    (content: string, props: { title: string }): Response
+    (content: string | Promise<string>, props: { title: string }): Response
   }
 }
 


### PR DESCRIPTION
![スクリーンショット 2024-01-18 11 57 09](https://github.com/honojs/website/assets/80559385/37b34c9e-61a2-4c36-a67a-d26eb628261a)
Hi, @yusukebe 
The type that was in the documentation could not support jsx that returned `Promise<string>`, so a type was added.