### PR TITLE
docs: update typo and add warning to `$url()` to use absolute URL

### DIFF
--- a/guides/rpc.md
+++ b/guides/rpc.md
@@ -136,7 +136,23 @@ const client = hc<AppType>('/api', {
 
 ## `$url()`
 
-You can get a `URL` object for accessing the the endpoint by using `$url()`.
+You can get a `URL` object for accessing the endpoint by using `$url()`.
+::: warning
+You have to pass in an absolute URL for this to work. Passing in a relative URL `/` will result in the following error.
+
+`Uncaught TypeError: Failed to construct 'URL': Invalid URL`
+
+```ts
+// ❌ Will throw error
+const client = hc<typeof route>('/')
+client.api.post.$url()
+
+// ✅ Will work as expected
+const client = hc<AppType>('http://localhost:8787')
+client.api.post.$url()
+```
+
+:::
 
 ```ts
 const route = app


### PR DESCRIPTION
Happy to change the wording, I had to dig around the debugging breakpoints to figure this out so thought it might be helpful to make it more clear.

<img width="1186" alt="image" src="https://github.com/honojs/website/assets/22161029/8db80aca-f208-409b-9e84-60e3e3b43bc9">
