### PR TITLE
Added auth.js in  third-party middlewares

### DIFF
--- a/middleware/third-party.md
+++ b/middleware/third-party.md
@@ -19,3 +19,4 @@ Most of this middleware leverages external libraries.
 - [Scalar API Reference](https://github.com/scalar/scalar/tree/main/packages/hono-api-reference)
 - [esbuild Transpiler](https://github.com/honojs/middleware/tree/main/packages/esbuild-transpiler)
 - [Prometheus Metrics](https://github.com/honojs/middleware/tree/main/packages/prometheus)
+- [Auth.js(Next Auth)](https://github.com/honojs/middleware/tree/main/packages/auth-js)


### PR DESCRIPTION
@yusukebe  auth.js was missing in third party middleware  readme this pr adds that.