### PR TITLE
docs: fix rpc building-a-larger-application link

### DIFF
--- a/guides/rpc.md
+++ b/guides/rpc.md
@@ -244,7 +244,7 @@ export default App
 
 ## Using with larger applications
 
-In the case of a larger application, such as the example mentioned in [Building a larger application](/guides/rpc#building-a-larger-application), you need to be careful about the type inference.
+In the case of a larger application, such as the example mentioned in [Building a larger application](/guides/best-practices#building-a-larger-application), you need to be careful about the type inference.
 A simple way to do this is to chain the handlers so that the types are always inferred.
 
 ```ts


### PR DESCRIPTION
# Overview
Addresses #237, by updating the link to "Building a Larger Application" in the RPC section for Using with larger applications to point to: `/guides/best-practices#building-a-larger-application`


# Screenshots


https://github.com/honojs/website/assets/43508242/c959c6c3-1f89-4ddc-a388-9712882be149


