### PR TITLE
docs(getting-started): static files on CF Workers

### DIFF
--- a/getting-started/cloudflare-workers.md
+++ b/getting-started/cloudflare-workers.md
@@ -183,6 +183,15 @@ app.get('/static/*', serveStatic({ root: './', manifest }))
 app.get('/favicon.ico', serveStatic({ path: './favicon.ico' }))
 ```
 
+TypeScript cannot resolve the special __STATIC_CONTENT_MANIFEST variable used to import the manifest. This variable is specific to Cloudflare Workers' environment and isn't recognized by TypeScript out of the box.
+You can tell TypeScript about this special module by declaring it in a type definition file. Create a new .d.ts file in your project, such as custom.d.ts, and add the following declaration:
+```ts
+declare module '__STATIC_CONTENT_MANIFEST' {
+  const manifest: { [key: string]: string };
+  export default manifest;
+}
+```
+
 See [Example](https://github.com/honojs/examples/tree/main/serve-static).
 
 ### `rewriteRequestPath`


### PR DESCRIPTION
there is a requirement to add a manifest to the serveStatic adapter method, the docs correctly shows that you need to import a manifest from the special __STATIC_CONTENT_MANIFEST module

However, this results in a Typescript error, as this module is generated by wrangler. This change to the docs explains how the user can add a type definition so that the error goes away, otherwise they may assume that the example is incorrect.