### PR TITLE
docs: Document integrating w/ other event handlers

### DIFF
--- a/getting-started/cloudflare-workers.md
+++ b/getting-started/cloudflare-workers.md
@@ -141,6 +141,21 @@ export default app
 
 But now, we recommend using Module Worker mode because such as that the binding variables are localized.
 
+## Using Hono with other event handlers
+
+You can integrate Hono with other event handlers (such as `scheduled`) in _Module Worker mode_. 
+
+To do this, export `app.fetch` as the module's `fetch` handler, and then implement other handlers as needed:
+
+```ts
+const app = new Hono()
+
+export default {
+  fetch: app.fetch,
+  scheduled: async (batch, env) => {}
+}
+```
+
 ## Serve static files
 
 You need to set it up to serve static files.


### PR DESCRIPTION
This PR adds a section in the Cloudflare Workers documentation on how to integrate a Hono app with other event handlers in a Module Worker.

This is based on @yusukebe's comment here: https://github.com/honojs/hono/issues/1720

I was looking to integrate a `scheduled` fn with my Hono app, and couldn't find anything in the docs for it. Hope this is useful!