### PR TITLE
Update Context.md setRenderer documentation, to correctly reflect what is needed to not get a typeerror.

### DIFF
--- a/api/context.md
+++ b/api/context.md
@@ -221,7 +221,7 @@ To ensure type safety, types can be defined as:
 ```ts
 declare module 'hono' {
   interface ContextRenderer {
-    (content: string | Promise<string>, head: { title: string }): Response
+    (content: string | Promise<string>, head: { title: string }): Response | Promise<Response>
   }
 }
 ```


### PR DESCRIPTION
```typescript
app.use('/pages/*', async (c, next) => {
  c.setRenderer((content, head) => {
    return c.html(
      <html lang='en'>
        <head>
          <title>{head.title}</title>
        </head>
        <body>
          <header>{head.title}</header>
          <p>{content}</p>
        </body>
      </html>
    )
  })
  await next()
})
```

Will throw a compile error if you don't have the ContextRenderer return a Response or Promise<Response>, like so

```typescript
declare module "hono" {
	interface ContextRenderer {
		(content: string | Promise<string>, head: { title: string }): Response | Promise<Response>;
	}
}
```