### PR TITLE
feat: Support vitepress-twoslash

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vitepress'
 import type { DefaultTheme } from 'vitepress'
+import { transformerTwoslash } from '@shikijs/vitepress-twoslash'
 
 const sidebars = (): DefaultTheme.SidebarItem[] => [
   {
@@ -194,6 +195,7 @@ export default defineConfig({
       light: 'github-light',
       dark: 'github-dark',
     },
+    codeTransformers: [transformerTwoslash()],
   },
   themeConfig: {
     logo: '/images/logo-small.png',

--- a/.vitepress/theme/index.js
+++ b/.vitepress/theme/index.js
@@ -1,4 +1,6 @@
 import { h } from 'vue'
+import TwoslashFloatingVue from '@shikijs/vitepress-twoslash/client'
+import '@shikijs/vitepress-twoslash/style.css'
 import DefaultTheme from 'vitepress/theme'
 import NotFound from './NotFound.vue'
 import './custom.css'
@@ -9,5 +11,8 @@ export default {
     return h(DefaultTheme.Layout, null, {
       'not-found': () => h(NotFound),
     })
+  },
+  enhanceApp({ app }) {
+    app.use(TwoslashFloatingVue)
   },
 }

--- a/getting-started/basic.md
+++ b/getting-started/basic.md
@@ -103,7 +103,7 @@ Write your first application with Hono in `src/index.ts`. The example below is a
 The `import` and the final `export default` parts may vary from runtime to runtime,
 but all of the application code will run the same code everywhere.
 
-```ts
+```ts twoslash
 import { Hono } from 'hono'
 
 const app = new Hono()

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "private": true,
   "license": "MIT",
   "devDependencies": {
-    "vitepress": "1.0.0-rc.24",
+    "@shikijs/vitepress-twoslash": "^1.1.6",
+    "vitepress": "1.0.0-rc.44",
     "vue": "^3.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "devDependencies": {
     "@shikijs/vitepress-twoslash": "^1.1.6",
+    "hono": "latest",
     "vitepress": "1.0.0-rc.44",
     "vue": "^3.3.4"
   }


### PR DESCRIPTION
### 🔗 Issues

### 🙋 Description

Support for using `@shikijs/vitepress-twoslash` in documents.
- refl: https://shiki.style/packages/vitepress

#### 📸 Usage and Captured image

````
```ts twoslash
import { Hono } from 'hono'

const app = new Hono()

app.get('/', (c) => {
  return c.text('Hello Hono!')
})

export default app
```
````

show ↓

<img width="500" src="https://github.com/honojs/website/assets/44604921/57261913-7a6c-4dca-9257-1450a672dc95" />

### ☑️ Checklist
 
- [ ] linked an issue or discussion
- [x] add example

### 📗 Note

I believe there is still some debate on such issues as "should it be displayed on all pages?"
Therefore, this PR focuses on "building the environment."

This PR is for use when “We want to use Twoslash on Hono.dev as well".
