### PR TITLE
docs(top): change in usages

### DIFF
--- a/top.md
+++ b/top.md
@@ -74,7 +74,7 @@ Here are some examples of use-cases.
 | ---------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------- |
 | [cdnjs](https://cdnjs.com)                     | Cloudflare Workers | A free and open-source CDN service. _Hono is used for the api server_.                    |
 | [Cloudflare Blog](https://blog.cloudflare.com) | Cloudflare Workers | _Some applications featured in the articles use Hono_.                                    |
-| [Unkey](https://unkey.dev/)                    | Cloudflare Workers | An open-source API authentication and authorization. _Hono is used for the api server_.   |
+| [Unkey](https://unkey.dev)                     | Cloudflare Workers | An open-source API authentication and authorization. _Hono is used for the api server_.   |
 | [OpenStatus](https://openstatus.dev)           | Bun                | An open-source website & API monitoring platform. _Hono is used for the api server_.      |
 | [Deno Benchmarks](https://deno.com/benchmarks) | Deno               | A secure TypeScript runtime built on V8. _Hono is used for benchmarking_.                 |
 

--- a/top.md
+++ b/top.md
@@ -73,7 +73,6 @@ Here are some examples of use-cases.
 | Project                                        | Platform           | What for?                                                                                 |
 | ---------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------- |
 | [cdnjs](https://cdnjs.com)                     | Cloudflare Workers | A free and open-source CDN service. _Hono is used for the api server_.                    |
-| [Cloudflare Blog](https://blog.cloudflare.com) | Cloudflare Workers | _Some applications featured in the articles use Hono_.                                    |
 | [Cloudflare D1](https://www.cloudflare.com/developer-platform/d1/)  | Cloudflare Workers | Serverless SQL databases. _Hono is used for the internal api server_.|
 | [Unkey](https://unkey.dev)                     | Cloudflare Workers | An open-source API authentication and authorization. _Hono is used for the api server_.   |
 | [OpenStatus](https://openstatus.dev)           | Bun                | An open-source website & API monitoring platform. _Hono is used for the api server_.      |

--- a/top.md
+++ b/top.md
@@ -74,14 +74,18 @@ Here are some examples of use-cases.
 | ---------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------- |
 | [cdnjs](https://cdnjs.com)                     | Cloudflare Workers | A free and open-source CDN service. _Hono is used for the api server_.                    |
 | [Cloudflare Blog](https://blog.cloudflare.com) | Cloudflare Workers | _Some applications featured in the articles use Hono_.                                    |
+| [Cloudflare D1](https://www.cloudflare.com/developer-platform/d1/)  | Cloudflare Workers | Serverless SQL databases. _Hono is used for the internal api server_.|
 | [Unkey](https://unkey.dev)                     | Cloudflare Workers | An open-source API authentication and authorization. _Hono is used for the api server_.   |
 | [OpenStatus](https://openstatus.dev)           | Bun                | An open-source website & API monitoring platform. _Hono is used for the api server_.      |
 | [Deno Benchmarks](https://deno.com/benchmarks) | Deno               | A secure TypeScript runtime built on V8. _Hono is used for benchmarking_.                 |
+| [Deno Docs](https://docs.deno.com/)            | Deno               | An official Deno documentation site. _Hono is used for the web server_.                   |
 
 And the following.
 
 - [Drivly](https://driv.ly/) - Cloudflare Workers
 - [repeat.dev](https://repeat.dev/) - Cloudflare Workers
+
+Do you want to see more? See [Who is using Hono in production?](https://github.com/orgs/honojs/discussions/1510).
 
 ## Hono in 1 minute
 

--- a/top.md
+++ b/top.md
@@ -71,7 +71,7 @@ Here are some examples of use-cases.
 ## Who is using Hono?
 
 | Project                                        | Platform           | What for?                                                                                 |
-| ---------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------|
+| ---------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------- |
 | [cdnjs](https://cdnjs.com)                     | Cloudflare Workers | A free and open-source CDN service. _Hono is used for the api server_.                    |
 | [Cloudflare Blog](https://blog.cloudflare.com) | Cloudflare Workers | _Some applications featured in the articles use Hono_.                                    |
 | [Unkey](https://unkey.dev/)                    | Cloudflare Workers | An open-source API authentication and authorization. _Hono is used for the api server_.   |

--- a/top.md
+++ b/top.md
@@ -73,8 +73,7 @@ Here are some examples of use-cases.
 | Project                                        | Platform           | What for?                                                                                 |
 | ---------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------- |
 | [cdnjs API Server](https://cdnjs.com/api)      | Cloudflare Workers | A free and open-source CDN service. _Hono is used for their API services_.                |
-| [Polyfill.io](https://www.polyfill.io/v3/)     | Fastly Compute     | A CDN service that provides necessary browser polyfills. _Hono is used as a core server_. |
-| [Ultra](https://ultrajs.dev)                   | Deno               | A React/Deno framework. _Hono is used for the internal server_.                           |
+| [OpenStatus](https://openstatus.dev)           | Bun                | A open-source website & API monitoring platform. _Hono is used for the api server_.       |
 | [Deno Benchmarks](https://deno.com/benchmarks) | Deno               | A secure TypeScript runtime built on V8. _Hono is used for benchmarking_.                 |
 | [Cloudflare Blog](https://blog.cloudflare.com) | Cloudflare Workers | _Some applications featured in the articles use Hono_.                                    |
 

--- a/top.md
+++ b/top.md
@@ -71,11 +71,12 @@ Here are some examples of use-cases.
 ## Who is using Hono?
 
 | Project                                        | Platform           | What for?                                                                                 |
-| ---------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------- |
-| [cdnjs API Server](https://cdnjs.com/api)      | Cloudflare Workers | A free and open-source CDN service. _Hono is used for their API services_.                |
-| [OpenStatus](https://openstatus.dev)           | Bun                | A open-source website & API monitoring platform. _Hono is used for the api server_.       |
-| [Deno Benchmarks](https://deno.com/benchmarks) | Deno               | A secure TypeScript runtime built on V8. _Hono is used for benchmarking_.                 |
+| ---------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------|
+| [cdnjs](https://cdnjs.com)                     | Cloudflare Workers | A free and open-source CDN service. _Hono is used for the api server_.                    |
 | [Cloudflare Blog](https://blog.cloudflare.com) | Cloudflare Workers | _Some applications featured in the articles use Hono_.                                    |
+| [Unkey](https://unkey.dev/)                    | Cloudflare Workers | An open-source API authentication and authorization. _Hono is used for the api server_.   |
+| [OpenStatus](https://openstatus.dev)           | Bun                | An open-source website & API monitoring platform. _Hono is used for the api server_.      |
+| [Deno Benchmarks](https://deno.com/benchmarks) | Deno               | A secure TypeScript runtime built on V8. _Hono is used for benchmarking_.                 |
 
 And the following.
 


### PR DESCRIPTION
Polyfill.io server has moved to Rust, so Hono is no longer in use.
Ultra also hasn't been updated for about half a year.

Add OpenStatus instead. I think this is a good usage to use Bun as a platform.