### PR TITLE
updated missing word "not"

### DIFF
--- a/concepts/stacks.md
+++ b/concepts/stacks.md
@@ -1,7 +1,7 @@
 # Hono Stacks
 
 Hono makes easy things easy and hard things easy.
-It is suitable for just only returning JSON.
+It is suitable for not just only returning JSON.
 But it's also great for building the full-stack application including REST API servers and the client.
 
 ## RPC


### PR DESCRIPTION
"It is suitable for not just only returning JSON."

"not" was missing there. as i feel.

adding "not" strongly  emphasizes that Hono's capabilities extend beyond merely returning JSON.