### PR TITLE
docs: Update cloudflare-pages.md

### DIFF
--- a/getting-started/cloudflare-pages.md
+++ b/getting-started/cloudflare-pages.md
@@ -161,7 +161,7 @@ Edit `wrangler.toml`. Specify Variable with the name `MY_NAME`.
 
 ```toml
 name = "my-project-name"
-compatibility_date = "2023-12-01"
+compatibility_date = "2024-03-18"
 
 [vars]
 MY_NAME = "Hono"


### PR DESCRIPTION
update the compatibility date. Ideally, this would be templated to always show today’s date. 