### PR TITLE
docs(pages): remove unnecessary settings in `wrangler.toml`

### DIFF
--- a/getting-started/cloudflare-pages.md
+++ b/getting-started/cloudflare-pages.md
@@ -160,9 +160,6 @@ touch wrangler.toml
 Edit `wrangler.toml`. Specify Variable with the name `MY_NAME`.
 
 ```toml
-name = "my-project-name"
-compatibility_date = "2024-03-18"
-
 [vars]
 MY_NAME = "Hono"
 ```


### PR DESCRIPTION
I've noticed that the settings that include `name` and `compatibility_date` are not necessary for `wrangler.toml` for Cloudflare Pages. Because it is used only in development and we can set the compatibility date in a Dashboard.