### PR TITLE
Fix pnpm deploy command

### DIFF
--- a/getting-started/cloudflare-pages.md
+++ b/getting-started/cloudflare-pages.md
@@ -135,7 +135,7 @@ yarn deploy
 ```
 
 ```txt [pnpm]
-pnpm deploy
+pnpm run deploy
 ```
 
 ```txt [bun]

--- a/getting-started/cloudflare-workers.md
+++ b/getting-started/cloudflare-workers.md
@@ -115,7 +115,7 @@ yarn deploy
 ```
 
 ```txt [pnpm]
-pnpm deploy
+pnpm run deploy
 ```
 
 ```txt [bun]


### PR DESCRIPTION
`pnpm deploy` is conflicting. Instead, do this: `pnpm run deploy`

```
$ pnpm deploy
ERR_PNPM_CANNOT_DEPLOY  A deploy is only possible from inside a workspace
```

https://pnpm.io/cli/deploy