### PR TITLE
docs(jwt-helper): add exp to jwt sign example

### DIFF
--- a/helpers/jwt.md
+++ b/helpers/jwt.md
@@ -35,6 +35,7 @@ import { sign } from 'hono/jwt'
 const payload = {
   sub: 'user123',
   role: 'admin',
+  exp: Math.floor(Date.now() / 1000) + 60 * 5, // Token expires in 5 minutes
 }
 const secret = 'mySecretKey'
 const token = await sign(payload, secret)
@@ -43,7 +44,7 @@ const token = await sign(payload, secret)
 ### Options
 
 - `payload`: unknown - required
-  - The JWT payload to be signed.
+  - The JWT payload to be signed. You can include other claims like in [Payload Validation](#payload-validation).
 - `secret`: string - required
   - The secret key used for JWT verification or signing.
 - `alg`: [AlgorithmTypes](#supported-algorithmtypes)


### PR DESCRIPTION
## Describe your changes
This PR will add exp to JWT helper `sign()` example section. This will help users get clarity on how to implement other JWT claims.

## Issues
[Add expires to JWT helper #2349](https://github.com/honojs/hono/issues/2349)
[Add IAT(issued at) and exp (expiration time)for jwt Tokens . #2407](https://github.com/honojs/hono/issues/2407)