### PR TITLE
chore: add vary header option to cache middleware docs

### DIFF
--- a/middleware/builtin/cache.md
+++ b/middleware/builtin/cache.md
@@ -60,3 +60,5 @@ app.get(
   - A boolean indicating if Hono should wait for the Promise of the `cache.put` function to resolve before continuing with the request. _Required to be true for the Deno environment_. Default is `false`.
 - `cacheControl`: string
   - A string of directives for the `Cache-Control` header. See the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) for more information. When this option is not provided, no `Cache-Control` header is added to requests.
+- `vary`: string | string[]
+  - Sets the `Vary` header in the response. If the original response header already contains a `Vary` header, the values are merged, removing any duplicates. Setting this to `*` will result in an error. For more details on the Vary header and its implications for caching strategies, refer to the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary).


### PR DESCRIPTION
This PR adds documentation for the `Vary` option in the cache middleware, which is scheduled for release in Hono version 4.2. For details on the implementation, please refer to [PR #2426](https://github.com/honojs/hono/pull/2426) on the Hono GitHub repository. 

|overview|only options|
|---|---|
|![localhost_5173_middleware_builtin_cache](https://github.com/honojs/website/assets/32933709/c90ff2fd-5684-4ea8-9b9c-0f061444d458)|![localhost_5173_middleware_builtin_cache (1)](https://github.com/honojs/website/assets/32933709/9ff374e4-6eda-4dde-925e-209502190f70)|