### PR TITLE
docs(trailing-slash): add documentation of `trailing-slash` middlewares

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -119,6 +119,7 @@ const sidebars = (): DefaultTheme.SidebarItem[] => [
       { text: 'JSX Renderer', link: '/middleware/builtin/jsx-renderer' },
       { text: 'JWT', link: '/middleware/builtin/jwt' },
       { text: 'Timing', link: '/middleware/builtin/timing' },
+      { text: 'Trailing Slash', link: '/middleware/builtin/trailing-slash' },
       { text: 'Logger', link: '/middleware/builtin/logger' },
       { text: 'Pretty JSON', link: '/middleware/builtin/pretty-json' },
       { text: 'Secure Headers', link: '/middleware/builtin/secure-headers' },

--- a/middleware/builtin/trailing-slash.md
+++ b/middleware/builtin/trailing-slash.md
@@ -1,0 +1,29 @@
+# Trailing Slash Middleware
+
+These middlewares resolve the trailing slash of URL on a GET request.
+
+## Import
+
+::: code-group
+
+```ts [npm]
+import { Hono } from 'hono'
+import { appendTrailingSlash, trimTrailingSlash } from 'hono/trailing-slash'
+```
+
+```ts [Deno]
+import { Hono } from 'https://deno.land/x/hono/mod.ts'
+import { appendTrailingSlash, trimTrailingSlash } from 'https://deno.land/x/hono/middleware.ts'
+```
+
+:::
+
+## Usage
+
+```ts
+const app = new Hono()
+
+app.get('*', appendTrailingSlash())
+// or
+app.get('*', trimTrailingSlash())
+```


### PR DESCRIPTION
As titled.