### PR TITLE
Include missing guide to make Docker work in Node.js

### DIFF
--- a/getting-started/nodejs.md
+++ b/getting-started/nodejs.md
@@ -232,6 +232,7 @@ RUN adduser --system --uid 1001 hono
 
 COPY --from=builder --chown=hono:nodejs /app/node_modules /app/node_modules
 COPY --from=builder --chown=hono:nodejs /app/dist /app/dist
+COPY --from=builder --chown=hono:nodejs /app/package.json /app/package.json
 
 USER hono
 EXPOSE 3000
@@ -245,3 +246,4 @@ The following steps shall be taken in advance.
 2. Add `"exclude": ["node_modules"]` to `tsconfig.json`.
 3. Add `"build": "tsc"` to `script` section of `package.json`.
 4. Run `npm install typescript --save-dev`.
+5. Add `"type": "module"` to `package.json`.


### PR DESCRIPTION
### Current

The setup guide provided at https://hono.dev/getting-started/nodejs for Docker doesn't work.

#### Steps to reproduce

- `npm create hono@latest my-app` Got `"@hono/node-server": "^1.9.0"` and `"hono": "^4.2.2"` in package.json
- `cd my-app`
- Created a Dockerfile according to the guide: https://hono.dev/getting-started/nodejs#dockerfile
- `docker build -t hono .`
- `docker run --rm -it --name hono -p 3000:3000 hono`

####  What was expected

It should run the app in the container which can be accessed via http://localhost:3000.

#### What's the current behavior

```
(node:1) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
/app/dist/index.js:1
import { serve } from '@hono/node-server';
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at internalCompileFunction (node:internal/vm:128:18)
    at wrapSafe (node:internal/modules/cjs/loader:1280:20)
    at Module._compile (node:internal/modules/cjs/loader:1332:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1427:10)
    at Module.load (node:internal/modules/cjs/loader:1206:32)
    at Module._load (node:internal/modules/cjs/loader:1022:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12)
    at node:internal/main/run_main_module:28:49

Node.js v20.12.1
```

#### Environment 

Node@20.9.0
npm@10.1.0
Docker version 24.0.6, build ed223bc 
Windows 23H2 (OS Build 22631.3296)

### Propose Fix

- Add to the Docker guide to include ```5. Add `"type": "module"` to `package.json`.```, though I'm not sure if this should be step five.
- Copy the package.json from the builder layer to the runner layer in Dockerfile.

#### Result

```
docker build -t hono --no-cache .
docker run --rm -it --name hono -p 3000:3000 hono
```

| | | |
| - | - | - |
| ![image](https://github.com/honojs/website/assets/16744414/36d432d3-c490-4488-a57d-3286115ffb7b) | ![image](https://github.com/honojs/website/assets/16744414/4ae081a5-90f4-450f-875b-20f748ec1e18) | ![image](https://github.com/honojs/website/assets/16744414/fcb16db3-d92e-4ef4-85f3-3f1bb0edd3c6) |
