### PR TITLE
Add new grouping example

### DIFF
--- a/api/routing.md
+++ b/api/routing.md
@@ -106,6 +106,24 @@ const app = new Hono()
 app.route('/book', book)
 ```
 
+## Grouping without changing base
+
+You can also group multiple instances while keeping base.
+
+```ts
+const book = new Hono()
+book.get('/book', (c) => c.text('List Books')) // GET /book
+book.post('/book', (c) => c.text('Create Book')) // POST /book
+
+const user = new Hono().basePath('/user')
+user.get('/user', (c) => c.text('List Users')) // GET /user
+user.post('/user', (c) => c.text('Create User')) // POST /user
+
+const app = new Hono()
+app.route('/', book) // Handle /book 
+app.route('/', user) // Handle /user 
+```
+
 ## Base path
 
 You can specify the base path.


### PR DESCRIPTION
When I migrated my app from Express to Hono, I needed this example.


## Express

```typescript
const book = express()
book.get('/book', ...)
book.post('/book', ...)

const user = express()
user.get('/user', ...)
user.post('/user', ...)

const app = user.use(book) // no base path needed
```


## Hono

```typescript
const book = new Hono()
book.get('/book', ...)
book.post('/book', ...)

const user = new Hono()
user.get('/user', ...)
user.post('/user', ...)

const app = user.route('/', book)
```



