### PR TITLE
Properly syntax highlight code blocks

### DIFF
--- a/getting-started/aws-lambda.md
+++ b/getting-started/aws-lambda.md
@@ -15,7 +15,7 @@ Initialize your project with the `cdk` CLI.
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 mkdir my-app
 cd my-app
 cdk init app -l typescript
@@ -23,7 +23,7 @@ npm i hono
 mkdir lambda
 ```
 
-```txt [yarn]
+```sh [yarn]
 mkdir my-app
 cd my-app
 cdk init app -l typescript
@@ -31,7 +31,7 @@ yarn add hono
 mkdir lambda
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 mkdir my-app
 cd my-app
 cdk init app -l typescript
@@ -39,7 +39,7 @@ pnpm add hono
 mkdir lambda
 ```
 
-```txt [bun]
+```sh [bun]
 mkdir my-app
 cd my-app
 cdk init app -l typescript
@@ -96,7 +96,7 @@ export class MyAppStack extends cdk.Stack {
 
 Finally, run the command to deploy:
 
-```
+```sh
 cdk deploy
 ```
 

--- a/getting-started/basic.md
+++ b/getting-started/basic.md
@@ -8,23 +8,23 @@ Starter templates are available for each platform. Use the following "create-hon
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 npm create hono@latest my-app
 ```
 
-```txt [yarn]
+```sh [yarn]
 yarn create hono my-app
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 pnpm create hono my-app
 ```
 
-```txt [bun]
+```sh [bun]
 bunx create-hono my-app
 ```
 
-```txt [deno]
+```sh [deno]
 deno run -A npm:create-hono my-app
 ```
 
@@ -50,22 +50,22 @@ The template will be pulled into `my-app`, so go to it and install the dependenc
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 cd my-app
 npm i
 ```
 
-```txt [yarn]
+```sh [yarn]
 cd my-app
 yarn
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 cd my-app
 pnpm i
 ```
 
-```txt [bun]
+```sh [bun]
 cd my-app
 bun i
 ```
@@ -76,19 +76,19 @@ Once the package installation is complete, run the following command to start up
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 npm run dev
 ```
 
-```txt [yarn]
+```sh [yarn]
 yarn dev
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 pnpm dev
 ```
 
-```txt [bun]
+```sh [bun]
 bun run dev
 ```
 
@@ -119,19 +119,19 @@ Start the development server and access `http://localhost:8787` with your browse
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 npm run dev
 ```
 
-```txt [yarn]
+```sh [yarn]
 yarn dev
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 pnpm dev
 ```
 
-```txt [bun]
+```sh [bun]
 bun run dev
 ```
 

--- a/getting-started/bun.md
+++ b/getting-started/bun.md
@@ -12,13 +12,13 @@ To install `bun` command, follow the instruction in [the official web site](http
 A starter for Bun is available. Start your project with "bun create" command.
 Select `bun` template for this example.
 
-```
+```sh
 bun create hono my-app
 ```
 
 Move into my-app and install the dependencies.
 
-```
+```sh
 cd my-app
 bun install
 ```
@@ -40,7 +40,7 @@ export default app
 
 Run the command.
 
-```ts
+```sh
 bun run --hot src/index.ts
 ```
 
@@ -157,6 +157,6 @@ describe('My first test', () => {
 
 Then, run the command.
 
-```
+```sh
 bun test index.test.ts
 ```

--- a/getting-started/cloudflare-pages.md
+++ b/getting-started/cloudflare-pages.md
@@ -14,23 +14,23 @@ Select `cloudflare-pages` template for this example.
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 npm create hono@latest my-app
 ```
 
-```txt [yarn]
+```sh [yarn]
 yarn create hono my-app
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 pnpm create hono my-app
 ```
 
-```txt [bun]
+```sh [bun]
 bunx create-hono my-app
 ```
 
-```txt [deno]
+```sh [deno]
 deno run -A npm:create-hono my-app
 ```
 
@@ -40,22 +40,22 @@ Move into `my-app` and install the dependencies.
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 cd my-app
 npm i
 ```
 
-```txt [yarn]
+```sh [yarn]
 cd my-app
 yarn
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 cd my-app
 pnpm i
 ```
 
-```txt [bun]
+```sh [bun]
 cd my-app
 bun i
 ```
@@ -102,19 +102,19 @@ Run the development server locally. Then, access `http://localhost:5173` in your
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 npm run dev
 ```
 
-```txt [yarn]
+```sh [yarn]
 yarn dev
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 pnpm dev
 ```
 
-```txt [bun]
+```sh [bun]
 bun run dev
 ```
 
@@ -126,19 +126,19 @@ If you have a Cloudflare account, you can deploy to Cloudflare. In `package.json
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 npm run deploy
 ```
 
-```txt [yarn]
+```sh [yarn]
 yarn deploy
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 pnpm run deploy
 ```
 
-```txt [bun]
+```sh [bun]
 bun run deploy
 ```
 
@@ -153,7 +153,7 @@ In this section, let's use Variables and KV.
 
 First, create `wrangler.toml` for local Bindings:
 
-```
+```sh
 touch wrangler.toml
 ```
 
@@ -168,7 +168,7 @@ MY_NAME = "Hono"
 
 Next, make the KV. Run the following `wrangler` command:
 
-```
+```sh
 wrangler kv:namespace create MY_KV --preview
 ```
 
@@ -295,6 +295,6 @@ export default defineConfig(({ mode }) => {
 
 You can run the following command to build the server and client script.
 
-```text
+```sh
 vite build --mode client && vite build
 ```

--- a/getting-started/cloudflare-workers.md
+++ b/getting-started/cloudflare-workers.md
@@ -15,23 +15,23 @@ Select `cloudflare-workers` template for this example.
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 npm create hono@latest my-app
 ```
 
-```txt [yarn]
+```sh [yarn]
 yarn create hono my-app
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 pnpm create hono my-app
 ```
 
-```txt [bun]
+```sh [bun]
 bunx create-hono my-app
 ```
 
-```txt [deno]
+```sh [deno]
 deno run -A npm:create-hono my-app
 ```
 
@@ -41,22 +41,22 @@ Move to `my-app` and install the dependencies.
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 cd my-app
 npm i
 ```
 
-```txt [yarn]
+```sh [yarn]
 cd my-app
 yarn
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 cd my-app
 pnpm i
 ```
 
-```txt [bun]
+```sh [bun]
 cd my-app
 bun i
 ```
@@ -82,19 +82,19 @@ Run the development server locally. Then, access `http://localhost:8787` in your
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 npm run dev
 ```
 
-```txt [yarn]
+```sh [yarn]
 yarn dev
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 pnpm dev
 ```
 
-```txt [bun]
+```sh [bun]
 bun run dev
 ```
 
@@ -106,19 +106,19 @@ If you have a Cloudflare account, you can deploy to Cloudflare. In `package.json
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 npm run deploy
 ```
 
-```txt [yarn]
+```sh [yarn]
 yarn deploy
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 pnpm run deploy
 ```
 
-```txt [bun]
+```sh [bun]
 bun run deploy
 ```
 
@@ -252,19 +252,19 @@ You have to install `@cloudflare/workers-types` if you want to have workers type
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 npm i --save-dev @cloudflare/workers-types
 ```
 
-```txt [yarn]
+```sh [yarn]
 yarn add -D @cloudflare/workers-types
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 pnpm add -D @cloudflare/workers-types
 ```
 
-```txt [bun]
+```sh [bun]
 bun add --dev @cloudflare/workers-types
 ```
 

--- a/getting-started/deno.md
+++ b/getting-started/deno.md
@@ -15,7 +15,7 @@ Please refer to [the official document](https://docs.deno.com/runtime/manual/get
 A starter for Deno is available.
 Start your project with "create-hono" command.
 
-```txt
+```sh
 deno run -A npm:create-hono my-app
 ```
 
@@ -23,7 +23,7 @@ Select `deno` template for this example.
 
 Move into `my-app`. For Deno, you don't have to install Hono explicitly.
 
-```
+```sh
 cd my-app
 ```
 
@@ -45,7 +45,7 @@ Deno.serve(app.fetch)
 
 Just this command:
 
-```
+```sh
 deno run --allow-net main.ts
 ```
 
@@ -162,7 +162,7 @@ Deno.test('Hello World', async () => {
 
 Then run the command:
 
-```
+```sh
 deno test hello.ts
 ```
 

--- a/getting-started/fastly.md
+++ b/getting-started/fastly.md
@@ -11,7 +11,7 @@ Then, install [Fastly CLI](https://github.com/fastly/cli).
 
 macOS
 
-```
+```sh
 brew install fastly/tap/fastly
 ```
 
@@ -27,23 +27,23 @@ Select `fastly` template for this example.
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 npm create hono@latest my-app
 ```
 
-```txt [yarn]
+```sh [yarn]
 yarn create hono my-app
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 pnpm create hono my-app
 ```
 
-```txt [bun]
+```sh [bun]
 bunx create-hono my-app
 ```
 
-```txt [deno]
+```sh [deno]
 deno run -A npm:create-hono my-app
 ```
 
@@ -53,22 +53,22 @@ Move to `my-app` and install the dependencies.
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 cd my-app
 npm i
 ```
 
-```txt [yarn]
+```sh [yarn]
 cd my-app
 yarn
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 cd my-app
 pnpm i
 ```
 
-```txt [bun]
+```sh [bun]
 cd my-app
 bun i
 ```
@@ -95,19 +95,19 @@ Run the development server locally. Then, access `http://localhost:7676` in your
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 npm run dev
 ```
 
-```txt [yarn]
+```sh [yarn]
 yarn dev
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 pnpm dev
 ```
 
-```txt [bun]
+```sh [bun]
 bun run dev
 ```
 
@@ -117,19 +117,19 @@ bun run dev
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 npm run deploy
 ```
 
-```txt [yarn]
+```sh [yarn]
 yarn deploy
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 pnpm deploy
 ```
 
-```txt [bun]
+```sh [bun]
 bun run deploy
 ```
 

--- a/getting-started/lambda-edge.md
+++ b/getting-started/lambda-edge.md
@@ -14,7 +14,7 @@ Initialize your project with the `cdk` CLI.
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 mkdir my-app
 cd my-app
 cdk init app -l typescript
@@ -22,7 +22,7 @@ npm i hono
 mkdir lambda
 ```
 
-```txt [yarn]
+```sh [yarn]
 mkdir my-app
 cd my-app
 cdk init app -l typescript
@@ -30,7 +30,7 @@ yarn add hono
 mkdir lambda
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 mkdir my-app
 cd my-app
 cdk init app -l typescript
@@ -38,7 +38,7 @@ pnpm add hono
 mkdir lambda
 ```
 
-```txt [bun]
+```sh [bun]
 mkdir my-app
 cd my-app
 cdk init app -l typescript
@@ -126,7 +126,7 @@ export class MyAppStack extends cdk.Stack {
 
 Finally, run the command to deploy:
 
-```
+```sh
 cdk deploy
 ```
 

--- a/getting-started/netlify.md
+++ b/getting-started/netlify.md
@@ -12,23 +12,23 @@ Select `netlify` template for this example.
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 npm create hono@latest my-app
 ```
 
-```txt [yarn]
+```sh [yarn]
 yarn create hono my-app
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 pnpm create hono my-app
 ```
 
-```txt [bun]
+```sh [bun]
 bunx create-hono my-app
 ```
 
-```txt [deno]
+```sh [deno]
 deno run -A npm:create-hono my-app
 ```
 
@@ -38,22 +38,22 @@ Move into `my-app` and install the dependencies.
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 cd my-app
 npm i
 ```
 
-```txt [yarn]
+```sh [yarn]
 cd my-app
 yarn
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 cd my-app
 pnpm i
 ```
 
-```txt [bun]
+```sh [bun]
 cd my-app
 bun i
 ```
@@ -83,7 +83,7 @@ export default handle(app)
 
 Run the development server with Netlify CLI. Then, access `http://localhost:8888` in your Web browser.
 
-```
+```sh
 netlify dev
 ```
 
@@ -91,7 +91,7 @@ netlify dev
 
 You can deploy with a `netlify deploy` command.
 
-```
+```sh
 netlify deploy --prod
 ```
 

--- a/getting-started/nodejs.md
+++ b/getting-started/nodejs.md
@@ -22,23 +22,23 @@ Select `nodejs` template for this example.
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 npm create hono@latest my-app
 ```
 
-```txt [yarn]
+```sh [yarn]
 yarn create hono my-app
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 pnpm create hono my-app
 ```
 
-```txt [bun]
+```sh [bun]
 bunx create-hono my-app
 ```
 
-```txt [deno]
+```sh [deno]
 deno run -A npm:create-hono my-app
 ```
 
@@ -47,22 +47,22 @@ Move to `my-app` and install the dependencies.
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 cd my-app
 npm i
 ```
 
-```txt [yarn]
+```sh [yarn]
 cd my-app
 yarn
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 cd my-app
 pnpm i
 ```
 
-```txt [bun]
+```sh [bun]
 cd my-app
 bun i
 ```
@@ -89,15 +89,15 @@ Run the development server locally. Then, access `http://localhost:3000` in your
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 npm run dev
 ```
 
-```txt [yarn]
+```sh [yarn]
 yarn dev
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 pnpm dev
 ```
 

--- a/getting-started/vercel.md
+++ b/getting-started/vercel.md
@@ -15,23 +15,23 @@ Select `nextjs` template for this example.
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 npm create hono@latest my-app
 ```
 
-```txt [yarn]
+```sh [yarn]
 yarn create hono my-app
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 pnpm create hono my-app
 ```
 
-```txt [bun]
+```sh [bun]
 bunx create-hono my-app
 ```
 
-```txt [deno]
+```sh [deno]
 deno run -A npm:create-hono my-app
 ```
 
@@ -41,22 +41,22 @@ Move into `my-app` and install the dependencies.
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 cd my-app
 npm i
 ```
 
-```txt [yarn]
+```sh [yarn]
 cd my-app
 yarn
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 cd my-app
 pnpm i
 ```
 
-```txt [bun]
+```sh [bun]
 cd my-app
 bun i
 ```
@@ -112,19 +112,19 @@ Run the development server locally. Then, access `http://localhost:3000` in your
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 npm run dev
 ```
 
-```txt [yarn]
+```sh [yarn]
 yarn dev
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 pnpm dev
 ```
 
-```txt [bun]
+```sh [bun]
 bun run dev
 ```
 
@@ -142,7 +142,7 @@ You can also run Hono on Next.js running on the Node.js runtime.
 
 First, install the Node.js adapter.
 
-```
+```sh
 npm i @hono/node-server
 ```
 

--- a/guides/validation.md
+++ b/guides/validation.md
@@ -72,19 +72,19 @@ Install from the Npm registry.
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 npm i zod
 ```
 
-```txt [yarn]
+```sh [yarn]
 yarn add zod
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 pnpm add zod
 ```
 
-```txt [bun]
+```sh [bun]
 bun add zod
 ```
 
@@ -135,19 +135,19 @@ You can use the [Zod Validator Middleware](https://github.com/honojs/middleware/
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 npm i @hono/zod-validator
 ```
 
-```txt [yarn]
+```sh [yarn]
 yarn add @hono/zod-validator
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 pnpm add @hono/zod-validator
 ```
 
-```txt [bun]
+```sh [bun]
 bun add @hono/zod-validator
 ```
 

--- a/middleware/builtin/bearer-auth.md
+++ b/middleware/builtin/bearer-auth.md
@@ -5,7 +5,7 @@ The HTTP clients accessing the endpoint will add the `Authorization` header with
 
 Using `curl` from the terminal, it would look like this:
 
-```
+```sh
 curl -H 'Authorization: Bearer honoiscool' http://localhost:8787/auth/page
 ```
 

--- a/snippets/htmx.md
+++ b/snippets/htmx.md
@@ -10,7 +10,7 @@ With using [typed-htmx](https://github.com/Desdaemon/typed-htmx), you can write 
 
 Install:
 
-```txt
+```sh
 npm i -D typed-htmx
 ```
 

--- a/top.md
+++ b/top.md
@@ -25,23 +25,23 @@ Just run this:
 
 ::: code-group
 
-```txt [npm]
+```sh [npm]
 npm create hono@latest
 ```
 
-```txt [yarn]
+```sh [yarn]
 yarn create hono
 ```
 
-```txt [pnpm]
+```sh [pnpm]
 pnpm create hono
 ```
 
-```txt [bun]
+```sh [bun]
 bunx create-hono
 ```
 
-```txt [deno]
+```sh [deno]
 deno run -A npm:create-hono
 ```
 


### PR DESCRIPTION
Many command examples were syntax-highlighted as `txt`, so they have been changed to `sh`. Additionally, command examples that were not syntax-highlighted have also been updated to include `sh` highlighting.

| Before | After |
|--------|--------|
| <img width="702" alt="Screenshot 2024-04-07 at 1 22 49" src="https://github.com/honojs/website/assets/7889778/36b75d2a-3598-424f-8be6-e9d4ba8b28b3"> | <img width="701" alt="Screenshot 2024-04-07 at 1 23 07" src="https://github.com/honojs/website/assets/7889778/1cc2d5ee-614b-4ad4-adcc-a3631c6a20c6"> | 