### PR TITLE
Update Bun and Deno run commands

### DIFF
--- a/getting-started/bun.md
+++ b/getting-started/bun.md
@@ -41,7 +41,7 @@ export default app
 Run the command.
 
 ```ts
-bun run --hot src/index.ts
+bun run dev
 ```
 
 Then, access `http://localhost:3000` in your browser.

--- a/getting-started/deno.md
+++ b/getting-started/deno.md
@@ -46,7 +46,7 @@ Deno.serve(app.fetch)
 Just this command:
 
 ```
-deno run --allow-net main.ts
+deno task start
 ```
 
 ## Change port number


### PR DESCRIPTION
To maintain consistency with other examples that use `npm run dev` as the command for running an app, I've modified the run commands for Bun and Deno. Since the templates for Bun and Deno include the necessary scripts (https://github.com/honojs/starter/blob/main/templates/bun/package.json#L3, https://github.com/honojs/starter/blob/main/templates/deno/deno.json#L3), this should not cause any issues.