### PR TITLE
Update Vercel page

### DIFF
--- a/getting-started/vercel.md
+++ b/getting-started/vercel.md
@@ -152,8 +152,13 @@ Next, you can utilize the `handle` function imported from `@hono/node-server/ver
 ```ts
 import { Hono } from 'hono'
 import { handle } from '@hono/node-server/vercel'
+import type { PageConfig } from 'next'
 
-
+export const config: PageConfig = {
+  api: {
+    bodyParser: false,
+  },
+}
 
 const app = new Hono().basePath('/api')
 

--- a/getting-started/vercel.md
+++ b/getting-started/vercel.md
@@ -90,10 +90,11 @@ If you use the Pages Router, Edit `pages/api/[[...route]].ts`.
 ```ts
 import { Hono } from 'hono'
 import { handle } from 'hono/vercel'
+import type { PageConfig } from 'next'
 
-export const config = {
+export const config: PageConfig = {
   runtime: "edge",
-};
+}
 
 const app = new Hono().basePath("/api")
 


### PR DESCRIPTION
Hello, and thanks for Hono! I've made two changes to the Vercel docs:

1. I added a TS type to the exported `config` object that some of the API routes use
2. To address https://github.com/honojs/node-server/issues/84, I updated the pages router Node.js example to have the `bodyParser` setting turned off. Based on my manual testing, this issue only affects the pages router API routes running on Node.js: the app router as a whole and page router edge API routes are not affected and as such don't need bodyParser turned off.