### PR TITLE
export default app to provide working basic jsx example for cf workers

### DIFF
--- a/guides/jsx.md
+++ b/guides/jsx.md
@@ -74,6 +74,8 @@ app.get('/', (c) => {
   const messages = ['Good Morning', 'Good Evening', 'Good Night']
   return c.html(<Top messages={messages} />)
 })
+
+export default app
 ```
 
 ## Fragment


### PR DESCRIPTION
The basic JSX example was missing the default export so it would break on cloudflare workers if you copy/pasted that snippet.