### PR TITLE
update landing page copy

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -165,6 +165,10 @@
   font-weight: 700 !important;
 }
 
+.tagline {
+  max-width: 500px !important;
+}
+
 .DocSearch-Button {
   background-color: var(--vp-c-bg-soft);
 }

--- a/index.md
+++ b/index.md
@@ -12,14 +12,14 @@ head:
 layout: home
 hero:
   name: Hono
-  text: Fast, Lightweight, Web-standards
-  tagline: Runs on any JavaScript runtime.
+  text: Web application framework
+  tagline: Fast, lightweight, built on web standards. Support for any JavaScript runtime.
   image:
     src: /images/code.webp
     alt: Hono
   actions:
     - theme: brand
-      text: View Docs
+      text: Get Started
       link: /top
     - theme: alt
       text: View on GitHub


### PR DESCRIPTION
this pull request updates the landing page copy of hono.dev.

a lot of people were asking in Hacker News "what does this do?" / "I can't tell what this is by the website".

the updates copy here re-focus hono in the lead title/subtitle as "Hono / Web application framework", with the perks being listed underneath in the paragraph.

the "View Docs" button text was updated to "Get Started". trying to guide people more to getting started as the immediate CTA button on the homepage.