### PR TITLE
chore: bump dependency vitepress to stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "private": true,
   "license": "MIT",
   "devDependencies": {
-    "vitepress": "1.0.0-rc.24",
+    "vitepress": "1.1.0",
     "vue": "^3.3.4"
   }
 }


### PR DESCRIPTION
We had a section in our console that reported an error from vitepress, which has been [fixed](https://github.com/vuejs/vitepress/issues/3389), so I think we should update the version, currently vitepress is out of RC to release a stable version.

<img width="750" alt="image" src="https://github.com/honojs/website/assets/3956400/aa5b97fe-89ef-47c1-81a3-25e6ca952453">


I've tested most of the pages locally and everything looks fine.