### PR TITLE
Add section on obtaining client IP address

### DIFF
--- a/getting-started/bun.md
+++ b/getting-started/bun.md
@@ -135,9 +135,17 @@ Bun.serve({
 });
 ```
 
-You can now access the IP address in `c.env.ip`
+You can now access the IP address in `c.env.ip` with the following output
 
-To ensure type safety, you can use bindings like this:
+```bash
+{
+  address: "1.1.1.1",
+  family: "IPv4",
+  port: 56071,
+}
+```
+
+To ensure type safety, you can use a Bindings generics as follows:
 
 ```ts
 import type { SocketAddress } from 'bun'

--- a/getting-started/bun.md
+++ b/getting-started/bun.md
@@ -136,3 +136,29 @@ Bun.serve({
 ```
 
 You can now access the IP address in `c.env.ip`
+
+To ensure type safety, you can use bindings like this:
+
+```ts
+import type { SocketAddress } from 'bun'
+import { Hono } from 'hono'
+
+type Bindings = {
+  ip: SocketAddress
+}
+
+const app = new Hono<{ Bindings: Bindings }>()
+
+app.get('/', (c) => {
+  return c.json({
+    yourIp: c.env.ip
+  })
+})
+
+Bun.serve({
+  fetch(req, server) {
+    return app.fetch(req, { ip: server.requestIP(req) })
+  }
+})
+```
+

--- a/getting-started/bun.md
+++ b/getting-started/bun.md
@@ -125,27 +125,7 @@ bun test index.test.ts
 ## Obtaining Request IP Address
 
 To obtain the IP address of the client, you need to use `Bun.serve`.
-
-```ts
-Bun.serve({
-  fetch(req, server) {
-    return app.fetch(req, { ip: server.requestIP(req)})
-
-  },
-});
-```
-
-You can now access the IP address in `c.env.ip` with the following output
-
-```bash
-{
-  address: "1.1.1.1",
-  family: "IPv4",
-  port: 56071,
-}
-```
-
-To ensure type safety, you can use a Bindings generics as follows:
+You can now access the IP address in `c.env.ip`. You can use Bindings generics to pass the IP to the context and ensure type safety.
 
 ```ts
 import type { SocketAddress } from 'bun'
@@ -159,7 +139,8 @@ const app = new Hono<{ Bindings: Bindings }>()
 
 app.get('/', (c) => {
   return c.json({
-    yourIp: c.env.ip
+    yourIp: c.env.ip 
+    // {yourIp: {"address": "1.1.1", "family": "IPv4", "port": 56071}}
   })
 })
 

--- a/getting-started/bun.md
+++ b/getting-started/bun.md
@@ -122,3 +122,17 @@ Then, run the command.
 ```
 bun test index.test.ts
 ```
+## Obtaining Request IP Address
+
+To obtain the IP address of the client, you need to use `Bun.serve`.
+
+```ts
+Bun.serve({
+  fetch(req, server) {
+    return app.fetch(req, { ip: server.requestIP(req)})
+
+  },
+});
+```
+
+You can now access the IP address in `c.env.ip`

--- a/getting-started/bun.md
+++ b/getting-started/bun.md
@@ -125,7 +125,7 @@ bun test index.test.ts
 ## Obtaining Request IP Address
 
 To obtain the IP address of the client, you need to use `Bun.serve`.
-You can now access the IP address in `c.env.ip`. You can use Bindings generics to pass the IP to the context and ensure type safety.
+You can use Bindings generics to pass the `ip` to the context and ensure type safety.
 
 ```ts
 import type { SocketAddress } from 'bun'


### PR DESCRIPTION
This has been a big question on Discord. Currently this is the only way I found to solve this issue. 

I understand if you do not want it added since it may not be the ideal way since the ip address is added to the env which is meant for environment variables.