### PR TITLE
Update htmx.md to add working instructions for using typed-htmx

### DIFF
--- a/snippets/htmx.md
+++ b/snippets/htmx.md
@@ -9,15 +9,13 @@ Using Hono with [htmx](https://htmx.org/).
 By using [typed-htmx](https://github.com/Desdaemon/typed-htmx), you can write JSX with TypeScript definitions for htmx attributes.
 We can follow the same pattern found on the [typed-htmx Example Project](https://github.com/Desdaemon/typed-htmx/blob/main/example/src/types.d.ts) to use it with `hono/jsx`.
 
-Install:
+Install the package:
 
 ```sh
 npm i -D typed-htmx
 ```
 
-`app/global.d.ts`:
-
-Import the `typed-htmx` types:
+On `src/global.d.ts` (or `app/global.d.ts` if you're using HonoX), import the `typed-htmx` types:
 
 ```ts
 import "typed-htmx";

--- a/snippets/htmx.md
+++ b/snippets/htmx.md
@@ -6,7 +6,8 @@ Using Hono with [htmx](https://htmx.org/).
 
 ### typed-htmx
 
-With using [typed-htmx](https://github.com/Desdaemon/typed-htmx), you can write the JSX with the type definitions of htmx.
+By using [typed-htmx](https://github.com/Desdaemon/typed-htmx), you can write JSX with TypeScript definitions for htmx attributes.
+We can follow the same pattern found on the [typed-htmx Example Project](https://github.com/Desdaemon/typed-htmx/blob/main/example/src/types.d.ts) to use it with `hono/jsx`.
 
 Install:
 
@@ -14,14 +15,24 @@ Install:
 npm i -D typed-htmx
 ```
 
-`tsconfig.json`:
+`global.d.ts`:
 
-```json
-{
-  "compilerOptions": {
-    "types": ["typed-htmx"],
-    "jsx": "react-jsx",
-    "jsxImportSource": "hono/jsx"
+Import the `typed-htmx` types:
+
+```ts
+import "typed-htmx";
+```
+
+Extend the Hono's JSX types with the typed-htmx definitions:
+
+```ts
+// A demo of how to augment foreign types with htmx attributes.
+// In this case, Hono sources its types from its own namespace, so we do the same
+// and directly extend its namespace.
+declare global {
+  namespace Hono {
+    interface HTMLAttributes extends HtmxAttributes {
+    }
   }
 }
 ```

--- a/snippets/htmx.md
+++ b/snippets/htmx.md
@@ -23,7 +23,7 @@ Import the `typed-htmx` types:
 import "typed-htmx";
 ```
 
-Extend the Hono's JSX types with the typed-htmx definitions:
+Extend Hono's JSX types with the typed-htmx definitions:
 
 ```ts
 // A demo of how to augment foreign types with htmx attributes.

--- a/snippets/htmx.md
+++ b/snippets/htmx.md
@@ -15,7 +15,7 @@ Install:
 npm i -D typed-htmx
 ```
 
-`global.d.ts`:
+`app/global.d.ts`:
 
 Import the `typed-htmx` types:
 


### PR DESCRIPTION
The current example for integrating `typed-html` with `hono/jsx` is outdated and doesn't work on current versions of both packages. I've updated the examples based on the instructions for [augmenting the JSX type definitions](https://github.com/Desdaemon/typed-htmx/blob/main/example/src/types.d.ts) for libraries which inject their own JSX types.