### PR TITLE
docs: fix the type issue of `c.var`

### DIFF
--- a/api/context.md
+++ b/api/context.md
@@ -17,7 +17,7 @@ app.get('/hello', (c) => {
 
 Return the HTTP response.
 
-You can set headers with `c.header()` and set HTTP status code with `c.status`.  
+You can set headers with `c.header()` and set HTTP status code with `c.status`.
 This can also be set in `c.text()`, `c.json()` and so on.
 
 ::: info
@@ -162,13 +162,15 @@ If you want to create the middleware which provides a custom method,
 write like the following:
 
 ```ts
-const app = new Hono()
-
-const echoMiddleware: MiddlewareHandler<{
+interface Env {
   Variables: {
     echo: (str: string) => string
   }
-}> = async (c, next) => {
+}
+
+const app = new Hono<Env>()
+
+const echoMiddleware: MiddlewareHandler<Env> = async (c, next) => {
   c.set('echo', (str) => str)
   await next()
 }

--- a/api/context.md
+++ b/api/context.md
@@ -162,7 +162,7 @@ If you want to create the middleware which provides a custom method,
 write like the following:
 
 ```ts
-interface Env {
+type Env = {
   Variables: {
     echo: (str: string) => string
   }
@@ -170,10 +170,10 @@ interface Env {
 
 const app = new Hono<Env>()
 
-const echoMiddleware: MiddlewareHandler<Env> = async (c, next) => {
+const echoMiddleware = createMiddleware<Env>(async (c, next) => {
   c.set('echo', (str) => str)
   await next()
-}
+})
 
 app.get('/echo', echoMiddleware, (c) => {
   return c.text(c.var.echo('Hello!'))

--- a/api/context.md
+++ b/api/context.md
@@ -168,7 +168,7 @@ type Env = {
   }
 }
 
-const app = new Hono<Env>()
+const app = new Hono()
 
 const echoMiddleware = createMiddleware<Env>(async (c, next) => {
   c.set('echo', (str) => str)
@@ -176,6 +176,19 @@ const echoMiddleware = createMiddleware<Env>(async (c, next) => {
 })
 
 app.get('/echo', echoMiddleware, (c) => {
+  return c.text(c.var.echo('Hello!'))
+})
+```
+
+If you want to use the middleware in multiple handlers, you can use `app.use()`.
+Then, you have to pass the `Env` as Generics to the constructor of `Hono` to make it type-safe.
+
+```ts
+const app = new Hono<Env>()
+
+app.use(echoMiddleware)
+
+app.get('/echo', (c) => {
   return c.text(c.var.echo('Hello!'))
 })
 ```


### PR DESCRIPTION
Sharing the Env types for making enables the `c.var` type-infer whether using the handler with no middleware or not.

https://github.com/honojs/hono/issues/2559