### PR TITLE
Fix mistake in Bun serve static

### DIFF
--- a/getting-started/bun.md
+++ b/getting-started/bun.md
@@ -83,7 +83,7 @@ For the above code, it will work well with the following directory structure.
 ```
 ./
 ├── favicon.ico
-├── index.ts
+├── src
 └── static
     ├── demo
     │   └── index.html


### PR DESCRIPTION
The reference to `index.ts` made it appear that the static folder was inside the `src` folder when root is set to `./`. Someone opened an issue thinking it was a bug [here](https://github.com/honojs/hono/issues/2565).