### PR TITLE
docs: remove mimes section in Node.js

### DIFF
--- a/getting-started/nodejs.md
+++ b/getting-started/nodejs.md
@@ -160,22 +160,6 @@ app.get(
 )
 ```
 
-### `mimes`
-
-You can add MIME types with `mimes`:
-
-```ts
-app.get(
-  '/static/*',
-  serveStatic({
-    mimes: {
-      m3u8: 'application/vnd.apple.mpegurl',
-      ts: 'video/mp2t',
-    }
-  })
-)
-```
-
 ## http2
 
 You can run hono on a [Node.js http2 Server](https://nodejs.org/api/http2.html).


### PR DESCRIPTION
This issue was asked on `quick-questions` on Discord.
`mimes` option has not been added to `@hono/node-server` yet, so we will temporarily remove it from the documentation.

Ref: https://github.com/honojs/node-server/pull/135