### PR TITLE
docs(rpc): Add "be" because it is missing.

### DIFF
--- a/guides/rpc.md
+++ b/guides/rpc.md
@@ -2,7 +2,7 @@
 
 The RPC feature allows sharing of the API specifications between the server and the client.
 
-You can export the types of input type specified by the Validator and the output type emitted by `json()`. And Hono Client will able to import it.
+You can export the types of input type specified by the Validator and the output type emitted by `json()`. And Hono Client will be able to import it.
 
 ## Server
 


### PR DESCRIPTION
I added "be" because "able" should be treated as an adjective.