### PR TITLE
docs(dev): fix typo in showRoutes options

### DIFF
--- a/helpers/dev.md
+++ b/helpers/dev.md
@@ -64,5 +64,5 @@ POST  /v1/posts
 
 - `verbose`: boolean - optional
   - When set to `true`, it displays verbose information.
-- `colorized`: boolean - optional
+- `colorize`: boolean - optional
   - When set to `false`, the output will not be colored.


### PR DESCRIPTION
Fix typo in `showRoutes` options at https://hono.dev/helpers/dev#options