### PR TITLE
docs[snippets]: add stripe webhook integration

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -184,6 +184,10 @@ const sidebarsSnippets = (): DefaultTheme.SidebarItem[] => [
         text: 'htmx',
         link: '/snippets/htmx',
       },
+      {
+        text: 'Stripe Webhook',
+        link: '/snippets/stripe-webhook'
+      }
     ],
   },
 ]

--- a/snippets/stripe-webhook.md
+++ b/snippets/stripe-webhook.md
@@ -1,0 +1,138 @@
+# Stripe Webhook Integration  
+
+This introduces how to create an API with Hono to receive Stripe Webhook events.
+
+## How to protect the API for Stripe Webhook events
+
+The API that processes webhook events is publicly accessible.
+
+```javascript
+import Stripe from 'stripe';
+import { Hono } from 'hono';
+const app = new Hono();
+
+app.post("/webhook", async (context) => {
+    const stripe = new Stripe(context.env.STRIPE_API_KEY);
+    const event = await context.req.json();
+    switch(event.type) {
+        case "payment_intent.created": {
+            console.log(event.data.object)
+            break
+        }
+        default:
+            break
+    }
+    return context.text("", 200);
+})
+
+export default app;
+```
+
+Therefore, a mechanism is needed to protect it from attacks such as malicious third parties spoofing Stripe's webhook event objects and sending requests. In Stripe's case, you can protect the API by issuing a webhook secret and verifying each request.
+
+Learn more: https://docs.stripe.com/webhooks?lang=node#verify-official-libraries  
+
+## Implementing the Webhook API by hosting environment or framework
+To perform signature verification with Stripe, the raw request body is needed.
+When using a framework, you need to ensure that the original body is not modified. If any changes are made to the raw request body, the verification will fail.
+
+Here, we introduce implementation methods for major hosting environments and frameworks.
+
+### Deploying to Cloudflare ( Workers / Pages )
+
+When processing Stripe webhook events on Cloudflare Workers or Cloudflare Pages functions, the raw request body can be obtained from `context.req.text()`.
+
+```diff
+import Stripe from 'stripe';
+import { Hono } from 'hono';
+const app = new Hono();
+
+app.post("/webhook", async (context) => {
+    const stripe = new Stripe(context.env.STRIPE_API_KEY);
+-    const event = await context.req.json();
++    const signature = context.req.header('stripe-signature');
++    try {
++        if (!signature) {
++            return context.text("", 400);
++        }
++        const body = await context.req.text();
++        const event = await stripe.webhooks.constructEventAsync(
++            body,
++            signature,
++            context.env.STRIPE_WEBHOOK_SECRET,
++            undefined,
++            Stripe.createSubtleCryptoProvider()
++        );
+        switch(event.type) {
+            case "payment_intent.created": {
+                console.log(event.data.object)
+                break
+            }
+            default:
+                break
+        }
+        return context.text("", 200);
++      } catch (err) {
++        const errorMessage = `⚠️  Webhook signature verification failed. ${err instanceof Error ? err.message : "Internal server error"}`
++        console.log(errorMessage);
++        return context.text(errorMessage, 400);
++      }
+})
+
+export default app;
+```
+
+### Deploying as a Node.js Application  
+
+For Node.js applications, the raw request body can be obtained from `Buffer.from(await request.arrayBuffer())`.
+
+```diff
+import Stripe from 'stripe';
+import { Hono } from 'hono';
+const app = new Hono();
+
+app.post("/webhook", async (context) => {
+    const stripe = new Stripe(context.env.STRIPE_API_KEY);
+-    const event = await context.req.json();
++    const signature = context.req.header('stripe-signature');
++    try {
++        if (!signature) {
++            return context.text("", 400);
++        }
++        const body = Buffer.from(await request.arrayBuffer());
++        const event = await stripe.webhooks.constructEventAsync(
++            body,
++            signature,
++            context.env.STRIPE_WEBHOOK_SECRET
++        );
+        switch(event.type) {
+            case "payment_intent.created": {
+                console.log(event.data.object)
+                break
+            }
+            default:
+                break
+        }
+        return context.text("", 200);
++      } catch (err) {
++        const errorMessage = `⚠️  Webhook signature verification failed. ${err instanceof Error ? err.message : "Internal server error"}`
++        console.log(errorMessage);
++        return context.text(errorMessage, 400);
++      }
+})
+
+export default app;
+```
+
+## Lear more
+
+- Details on Stripe Webhooks:
+https://docs.stripe.com/webhooks
+- Implementing for payment processing: 
+https://docs.stripe.com/payments/handling-payment-events
+- Implementing for subscriptions:
+https://docs.stripe.com/billing/subscriptions/webhooks
+- List of webhook events sent by Stripe:
+https://docs.stripe.com/api/events
+- Sample template for Cloudflare:
+https://github.com/stripe-samples/stripe-node-cloudflare-worker-template/

--- a/snippets/stripe-webhook.md
+++ b/snippets/stripe-webhook.md
@@ -2,6 +2,27 @@
 
 This introduces how to create an API with Hono to receive Stripe Webhook events.
 
+## Preparation
+
+Please install the official Stripe SDK at first:
+
+```bash
+% npm install stripe
+```
+
+And put the following values on the `.dev.vars` file to insert the Stripe API keys:
+
+```
+STRIPE_API_KEY=sk_test_xxx
+STRIPE_WEBHOOK_SECRET=whsec_xxx
+```
+
+You can learn about the Stripe API keys by the following documents:
+
+- Secret Key: https://docs.stripe.com/keys
+- Webhook secret: https://docs.stripe.com/webhooks
+
+
 ## How to protect the API for Stripe Webhook events
 
 The API that processes webhook events is publicly accessible.

--- a/snippets/stripe-webhook.md
+++ b/snippets/stripe-webhook.md
@@ -44,33 +44,33 @@ const app = new Hono();
 app.post("/webhook", async (context) => {
     const { STRIPE_SECRET_API_KEY, STRIPE_WEBHOOK_SECRET } = env(context);
     const stripe = new Stripe(STRIPE_SECRET_API_KEY);
-    const event = await context.req.json(); // [!code --]
-    const signature = context.req.header('stripe-signature'); // [!code ++]
-    try { // [!code ++]
-        if (!signature) { // [!code ++]
-            return context.text("", 400); // [!code ++]
-        } // [!code ++]
-        const body = await context.req.text(); // [!code ++]
-        const event = await stripe.webhooks.constructEventAsync( // [!code ++]
-            body, // [!code ++]
-            signature, // [!code ++]
-            STRIPE_WEBHOOK_SECRET // [!code ++]
-        ); // [!code ++]
+    const event = await context.req.json();
+    const signature = context.req.header('stripe-signature');
+    try {
+        if (!signature) {
+            return context.text("", 400);
+        }
+        const body = await context.req.text();
+        const event = await stripe.webhooks.constructEventAsync(
+            body,
+            signature,
+            STRIPE_WEBHOOK_SECRET
+        );
         switch(event.type) {
             case "payment_intent.created": {
-                console.log(event.data.object)
+                console.log(event.data.object);
                 break
             }
             default:
                 break
         }
         return context.text("", 200);
-      } catch (err) { // [!code ++]
-        const errorMessage = `⚠️  Webhook signature verification failed. ${err instanceof Error ? err.message : "Internal server error"}` // [!code ++]
-        console.log(errorMessage); // [!code ++]
-        return context.text(errorMessage, 400); // [!code ++]
-      } // [!code ++]
-})
+      } catch (err) {
+        const errorMessage = `⚠️  Webhook signature verification failed. ${err instanceof Error ? err.message : "Internal server error"}`;
+        console.log(errorMessage);
+        return context.text(errorMessage, 400);
+      }
+});
 
 export default app;
 ```

--- a/snippets/stripe-webhook.md
+++ b/snippets/stripe-webhook.md
@@ -22,37 +22,9 @@ You can learn about the Stripe API keys by the following documents:
 - Secret Key: https://docs.stripe.com/keys
 - Webhook secret: https://docs.stripe.com/webhooks
 
-
 ## How to protect the API for Stripe Webhook events
 
-The API that processes webhook events is publicly accessible.
-
-```javascript
-import Stripe from 'stripe';
-import { Hono } from 'hono';
-import { env } from 'hono/adapter';
-
-const app = new Hono();
-
-app.post("/webhook", async (context) => {
-    const { STRIPE_SECRET_API_KEY } = env(context);
-    const stripe = new Stripe(STRIPE_SECRET_API_KEY);
-    const event = await context.req.json();
-    switch(event.type) {
-        case "payment_intent.created": {
-            console.log(event.data.object)
-            break
-        }
-        default:
-            break
-    }
-    return context.text("", 200);
-})
-
-export default app;
-```
-
-Therefore, a mechanism is needed to protect it from attacks such as malicious third parties spoofing Stripe's webhook event objects and sending requests. In Stripe's case, you can protect the API by issuing a webhook secret and verifying each request.
+The API that processes webhook events is publicly accessible.Therefore, a mechanism is needed to protect it from attacks such as malicious third parties spoofing Stripe's webhook event objects and sending requests. In Stripe's case, you can protect the API by issuing a webhook secret and verifying each request.
 
 Learn more: https://docs.stripe.com/webhooks?lang=node#verify-official-libraries  
 
@@ -62,7 +34,7 @@ When using a framework, you need to ensure that the original body is not modifie
 
 In the case of Hono, we can get the raw request body by the `context.req.text()` method. So we can create the webhook API like the following example:
 
-```js
+```ts
 import Stripe from 'stripe';
 import { Hono } from 'hono';
 import { env } from 'hono/adapter';

--- a/snippets/stripe-webhook.md
+++ b/snippets/stripe-webhook.md
@@ -7,7 +7,7 @@ This introduces how to create an API with Hono to receive Stripe Webhook events.
 Please install the official Stripe SDK at first:
 
 ```bash
-% npm install stripe
+npm install stripe
 ```
 
 And put the following values on the `.dev.vars` file to insert the Stripe API keys:

--- a/snippets/stripe-webhook.md
+++ b/snippets/stripe-webhook.md
@@ -63,27 +63,27 @@ Here, we introduce implementation methods for major hosting environments and fra
 
 When processing Stripe webhook events on Cloudflare Workers or Cloudflare Pages functions, the raw request body can be obtained from `context.req.text()`.
 
-```diff
+```js
 import Stripe from 'stripe';
 import { Hono } from 'hono';
 const app = new Hono();
 
 app.post("/webhook", async (context) => {
     const stripe = new Stripe(context.env.STRIPE_API_KEY);
--    const event = await context.req.json();
-+    const signature = context.req.header('stripe-signature');
-+    try {
-+        if (!signature) {
-+            return context.text("", 400);
-+        }
-+        const body = await context.req.text();
-+        const event = await stripe.webhooks.constructEventAsync(
-+            body,
-+            signature,
-+            context.env.STRIPE_WEBHOOK_SECRET,
-+            undefined,
-+            Stripe.createSubtleCryptoProvider()
-+        );
+    const event = await context.req.json(); // [!code --]
+    const signature = context.req.header('stripe-signature'); // [!code ++]
+    try { // [!code ++]
+        if (!signature) { // [!code ++]
+            return context.text("", 400); // [!code ++]
+        } // [!code ++]
+        const body = await context.req.text(); // [!code ++]
+        const event = await stripe.webhooks.constructEventAsync( // [!code ++]
+            body, // [!code ++]
+            signature, // [!code ++]
+            context.env.STRIPE_WEBHOOK_SECRET, // [!code ++]
+            undefined, // [!code ++]
+            Stripe.createSubtleCryptoProvider() // [!code ++]
+        ); // [!code ++]
         switch(event.type) {
             case "payment_intent.created": {
                 console.log(event.data.object)
@@ -93,11 +93,11 @@ app.post("/webhook", async (context) => {
                 break
         }
         return context.text("", 200);
-+      } catch (err) {
-+        const errorMessage = `⚠️  Webhook signature verification failed. ${err instanceof Error ? err.message : "Internal server error"}`
-+        console.log(errorMessage);
-+        return context.text(errorMessage, 400);
-+      }
+      } catch (err) { // [!code ++]
+        const errorMessage = `⚠️  Webhook signature verification failed. ${err instanceof Error ? err.message : "Internal server error"}` // [!code ++]
+        console.log(errorMessage); // [!code ++]
+        return context.text(errorMessage, 400); // [!code ++]
+      } // [!code ++]
 })
 
 export default app;
@@ -107,25 +107,25 @@ export default app;
 
 For Node.js applications, the raw request body can be obtained from `Buffer.from(await request.arrayBuffer())`.
 
-```diff
+```js
 import Stripe from 'stripe';
 import { Hono } from 'hono';
 const app = new Hono();
 
 app.post("/webhook", async (context) => {
     const stripe = new Stripe(context.env.STRIPE_API_KEY);
--    const event = await context.req.json();
-+    const signature = context.req.header('stripe-signature');
-+    try {
-+        if (!signature) {
-+            return context.text("", 400);
-+        }
-+        const body = Buffer.from(await request.arrayBuffer());
-+        const event = await stripe.webhooks.constructEventAsync(
-+            body,
-+            signature,
-+            context.env.STRIPE_WEBHOOK_SECRET
-+        );
+    const event = await context.req.json(); // [!code --]
+    const signature = context.req.header('stripe-signature'); // [!code ++]
+    try { // [!code ++]
+        if (!signature) { // [!code ++]
+            return context.text("", 400); // [!code ++]
+        } // [!code ++]
+        const body = Buffer.from(await request.arrayBuffer()); // [!code ++]
+        const event = await stripe.webhooks.constructEventAsync( // [!code ++]
+            body, // [!code ++]
+            signature, // [!code ++]
+            context.env.STRIPE_WEBHOOK_SECRET // [!code ++]
+        ); // [!code ++]
         switch(event.type) {
             case "payment_intent.created": {
                 console.log(event.data.object)
@@ -135,11 +135,11 @@ app.post("/webhook", async (context) => {
                 break
         }
         return context.text("", 200);
-+      } catch (err) {
-+        const errorMessage = `⚠️  Webhook signature verification failed. ${err instanceof Error ? err.message : "Internal server error"}`
-+        console.log(errorMessage);
-+        return context.text(errorMessage, 400);
-+      }
+      } catch (err) { // [!code ++]
+        const errorMessage = `⚠️  Webhook signature verification failed. ${err instanceof Error ? err.message : "Internal server error"}` // [!code ++]
+        console.log(errorMessage); // [!code ++]
+        return context.text(errorMessage, 400); // [!code ++]
+      } // [!code ++]
 })
 
 export default app;


### PR DESCRIPTION
I added a page introducing how to create an API using Hono to handle Stripe Webhook events.

## Context 
https://github.com/orgs/honojs/discussions/2518#discussioncomment-9170675

To add protection processing for the API endpoint, Stripe Webhooks require the raw request body. I created an article with sample code explaining how to obtain this for both Node.js and Cloudflare.

By adding this article, users using Stripe with Hono will find it easier to understand the integration method, and it will be easier to provide support in case of issues or discussions.
