### PR TITLE
add warning about Bun's default request body limit

### DIFF
--- a/middleware/builtin/body-limit.md
+++ b/middleware/builtin/body-limit.md
@@ -50,3 +50,24 @@ app.post(
   - The maximum file size of the file you want to limit. The default is `100 * 1024` - `100kb`.
 - `onError`: `OnError`
   - The error handler to be invoked if the specified file size is exceeded.
+
+## Usage with Bun for large requests
+If the Body Limit Middleware is used explicitly to allow a request body larger than than the default, it might be necessary to make changes to your `Bun.serve` configuration accordingly. [At the time of writing](https://github.com/oven-sh/bun/blob/f2cfa15e4ef9d730fc6842ad8b79fb7ab4c71cb9/packages/bun-types/bun.d.ts#L2191), `Bun.serve`'s default request body limit is 128MiB. If you set Hono's Body Limit Middleware to a value bigger than that, your requests will still fail and, additionally, the `onError` handler specified in the middleware will not be called. This is because `Bun.serve()` will set the status code to `413` and terminate the connection before passing the request to Hono.
+
+If you want to accept requests larger than 128MiB with Hono and Bun, you need to set the limit for Bun as well:
+```ts
+export default {
+  port: process.env["PORT"] || 3000,
+  fetch: app.fetch,
+  maxRequestBodySize: 1024 * 1024 * 200, // your value here
+};
+```
+or, depending on your setup:
+```ts
+Bun.serve({
+  fetch(req, server) {
+    return app.fetch(req, { ip: server.requestIP(req) })
+  },
+  maxRequestBodySize: 1024 * 1024 * 200, // your value here
+})
+``` 


### PR DESCRIPTION
In reference to honojs/hono#2671,

Bun terminates requests above 128MiB by default. Setting the Hono `bodyLimit` middleware to a higher value will not help as the request is terminated before it even reaches Hono. Additionally, Bun does not provide an explicit error about this and the `onError` handler on Hono's `bodyLimit` middleware doesn't get called either, making errors hard to debug.

A section is added to warn users about this behavior with mitigation steps.