### PR TITLE
docs(helpers/testing): fix typo

### DIFF
--- a/helpers/testing.md
+++ b/helpers/testing.md
@@ -15,7 +15,7 @@ import { testClient } from 'hono/testing'
 
 ## `testClient()`
 
-The `testingClient()` takes an instance of Hono as its first argument and returns an object of the [Hono Client](/guides/rpc#client). By using this, you can define your request with the editor completion.
+The `testClient()` takes an instance of Hono as its first argument and returns an object of the [Hono Client](/guides/rpc#client). By using this, you can define your request with the editor completion.
 
 ```ts
 import { testClient } from 'hono/testing'


### PR DESCRIPTION
Change '`testingClient()`' to '`testClient()`'