### PR TITLE
Typo on stripe-webhook.md

### DIFF
--- a/snippets/stripe-webhook.md
+++ b/snippets/stripe-webhook.md
@@ -75,7 +75,7 @@ export default app;
 ```
 
 
-## Lear more
+## Learn more
 
 - Details on Stripe Webhooks:
 https://docs.stripe.com/webhooks


### PR DESCRIPTION
"Lear More" appears in heading on line 72. 