### PR TITLE
feat: Replacement to TSDoc for API documentation

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -232,6 +232,7 @@ export default defineConfig({
         'Copyright © 2022-present Yusuke Wada & Hono contributors. "kawaii" logo is created by SAWARATSUKI.',
     },
     nav: [
+      { text: 'API', link: '/api' },
       { text: 'Docs', link: '/top' },
       { text: 'Snippets', link: '/snippets/top' },
       { text: 'Examples', link: 'https://github.com/honojs/examples' },

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -1,5 +1,6 @@
-import { defineConfig } from 'vitepress'
 import type { DefaultTheme } from 'vitepress'
+import { defineConfig } from 'vitepress'
+import typedocSidebar from '../docs/api/typedoc-sidebar.json'
 
 const sidebars = (): DefaultTheme.SidebarItem[] => [
   {
@@ -232,7 +233,7 @@ export default defineConfig({
         'Copyright © 2022-present Yusuke Wada & Hono contributors. "kawaii" logo is created by SAWARATSUKI.',
     },
     nav: [
-      { text: 'API', link: '/api' },
+      { text: 'API', link: '/docs/api/' },
       { text: 'Docs', link: '/top' },
       { text: 'Snippets', link: '/snippets/top' },
       { text: 'Examples', link: 'https://github.com/honojs/examples' },
@@ -240,6 +241,7 @@ export default defineConfig({
     ],
     sidebar: {
       '/': sidebars(),
+      '/docs/api/': typedocSidebar,
       '/snippets/': sidebarsSnippets(),
     },
   },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "typedoc": "^0.25.13",
     "typedoc-plugin-markdown": "^4.0.3",
+    "typedoc-vitepress-theme": "^1.0.0",
     "vitepress": "1.1.0",
     "vue": "^3.3.4"
   }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "private": true,
   "license": "MIT",
   "devDependencies": {
+    "typedoc": "^0.25.13",
     "vitepress": "1.1.0",
     "vue": "^3.3.4"
   }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "devDependencies": {
     "typedoc": "^0.25.13",
+    "typedoc-plugin-markdown": "^4.0.3",
     "vitepress": "1.1.0",
     "vue": "^3.3.4"
   }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,67 @@
+{
+  "plugin": ["typedoc-plugin-markdown", "typedoc-vitepress-theme"],
+  "entryPoints": ["temp_src/**/*.ts"],
+  "entryPointStrategy": "resolve",
+  "outputFileStrategy": "members",
+  "out": "docs/api",
+  "jsDocCompatibility": {
+    "defaultTag": true,
+    "exampleTag": true
+  },
+  "exclude": ["**/*.test.ts*", "**/types.ts", "**/test-utils/**/*"],
+
+  "searchInComments": false,
+
+  // skip typescript error checking
+  "skipErrorChecking": true,
+
+  // clean output directory
+  "cleanOutputDir": true,
+
+  //
+  // "commentStyle": "line",
+
+  // ignore private, external and protected variables and methods.
+  "excludePrivate": true,
+  "excludeExternals": true,
+  "excludeProtected": true,
+
+  // don't include source file location in docs
+  "disableSources": true,
+
+  // typedoc-plugin-markdown options
+  "mergeReadme": true,
+  "hidePageHeader": true,
+  "hideBreadcrumbs": true,
+  "useCodeBlocks": true,
+  "expandObjects": true,
+  "expandParameters": true,
+  "parametersFormat": "table",
+  "propertiesFormat": "list",
+
+  // we're not using github pages to deploy hono.dev
+  "githubPages": false,
+
+  "validation": {
+    "notExported": false,
+    "notDocumented": true,
+    "invalidLink": true
+  },
+
+  "navigationModel": {
+    // disable groups organization (type aliases, variables, function, etc.)
+    // this makes moving in the docs faster
+    "excludeGroups": true,
+
+    // don't organize by group (type aliases, variables, function, etc.)
+    "excludeCategories": true,
+
+    // organize by folders
+    "excludeFolders": false
+  },
+
+  "sidebar": {
+    "collapse": false,
+    "pretty": true
+  }
+}


### PR DESCRIPTION
As [proposed by @yusukebe (Replacement to TSDoc for API documentation)(https://github.com/orgs/honojs/discussions/2854).

I will be working on implementing this in the meantime.

<br />

Main goals:
- API references should have a similar style and format to the Docs.
- For faster maintenance, auto-generate with every new build of the site.

<br />

API docs automatic generation process:
- Clone source code from honojs/hono in a temporary folder
- Run `typedoc` to generate the docs
- Delete source code files of Hono
- *Run the usual build process...*

<br />

Thanks for discussing the proposal:
- @goisaki 
- @yusukebe 
- @NicoPlyley 