### PR TITLE
docs: improve cloudflare-workers page

### DIFF
--- a/getting-started/cloudflare-workers.md
+++ b/getting-started/cloudflare-workers.md
@@ -140,7 +140,9 @@ app.fire()
 export default app
 ```
 
+::: info
 But now, we recommend using Module Worker mode because such as that the binding variables are localized.
+:::
 
 ## Using Hono with other event handlers
 


### PR DESCRIPTION
Highlighted the information on module worker vs service worker regarding the local variables. The information wasn't highlighted so that new users of cloudflare worker runtime can find why their local environment variables aren't working.