### PR TITLE
docs: reword cloudflare-workers section on service worker mode vs module worker mode

### DIFF
--- a/getting-started/cloudflare-workers.md
+++ b/getting-started/cloudflare-workers.md
@@ -128,21 +128,17 @@ That's all!
 
 ## Service Worker mode or Module Worker mode
 
-There are two syntaxes for writing the Cloudflare Workers. _Service Worker mode_ and _Module Worker mode_. Using Hono, you can write with both syntax:
-
-```ts
-// Service Worker
-app.fire()
-```
+There are two syntaxes for writing the Cloudflare Workers. _Module Worker mode_ and _Service Worker mode_. Using Hono, you can write with both syntax, but we recommend using Module Worker mode so that binding variables are localized.
 
 ```ts
 // Module Worker
 export default app
 ```
 
-::: info
-But now, we recommend using Module Worker mode because such as that the binding variables are localized.
-:::
+```ts
+// Service Worker
+app.fire()
+```
 
 ## Using Hono with other event handlers
 


### PR DESCRIPTION
put module workers first since they're the recommended way 
move justification into the same paragraph to make sure it gets read

I had the same problem as [this commenter](https://github.com/honojs/hono/issues/194#issuecomment-2143549646). To me, this is clearer and points users more clearly to the happy path