### PR TITLE
docs: use JSR instead of deno.land/x

### DIFF
--- a/getting-started/deno.md
+++ b/getting-started/deno.md
@@ -150,11 +150,15 @@ Hono also supports Deno Deploy. Please refer to [the official document](https://
 ## Testing
 
 Testing the application on Deno is easy.
-You can write with `Deno.test` and use `assert` or `assertEquals` from the standard library.
+You can write with `Deno.test` and use `assert` or `assertEquals` from [@std/assert](https://jsr.io/@std/assert).
+
+```sh
+deno add @std/assert
+```
 
 ```ts
 import { Hono } from 'hono'
-import { assertEquals } from 'https://deno.land/std/assert/mod.ts'
+import { assertEquals } from '@std/assert'
 
 Deno.test('Hello World', async () => {
   const app = new Hono()

--- a/guides/middleware.md
+++ b/guides/middleware.md
@@ -102,8 +102,8 @@ app.use(
 In Deno, it is possible to use a different version of middleware than the Hono version, but this can lead to bugs.
 For example, this code is not working because the version is different.
 ```ts
-import { Hono } from 'https://deno.land/x/hono@v2.0.0/mod.ts'
-import { upgradeWebSocket } from 'https://deno.land/x/hono@v4.1.4/helper.ts'
+import { Hono } from 'jsr:@hono/hono@4.4.0'
+import { upgradeWebSocket } from 'jsr:@hono/hono@4.4.5/deno'
 
 const app = new Hono()
 

--- a/guides/others.md
+++ b/guides/others.md
@@ -23,4 +23,4 @@ You can sponsor Hono authors via the GitHub sponsor program.
 
 - GitHub repository: <a href="https://github.com/honojs">https://github.com/honojs</a>
 - npm registry: <a href="https://www.npmjs.com/package/hono">https://www.npmjs.com/package/hono</a>
-- Deno module: <a href="https://deno.land/x/hono">https://deno.land/x/hono</a>
+- JSR: <a href="https://jsr.io/@hono/hono">https://jsr.io/@hono/hono</a>


### PR DESCRIPTION
Hono is no longer updated on deno.land/x, so change to JSR.
Since Deno also recommends JSR, use JSR instead of deno.land.