### PR TITLE
docs: use hono/bun instead in adapter example

### DIFF
--- a/getting-started/basic.md
+++ b/getting-started/basic.md
@@ -230,10 +230,10 @@ And, you can make your own middleware.
 ## Adapter
 
 There are Adapters for platform-dependent functions, e.g., handling static files.
-For example, to handle static files in Cloudflare Workers, import `hono/cloudflare-workers`.
+For example, to handle static files in Bun, import `hono/bun`.
 
 ```ts
-import { serveStatic } from 'hono/cloudflare-workers'
+import { serveStatic } from 'hono/bun'
 
 app.get('/static/*', serveStatic({ root: './' }))
 ```


### PR DESCRIPTION
serveStatic() for Cloudflare-workers is deprecated, so change to Bun instead.
I thought of using websocket as an example, but I thought serveStatic() would be easier to understand, so I changed it to Bun.