### PR TITLE
docs: use `upgradeWebSocket()` instead in adapter example

### DIFF
--- a/getting-started/basic.md
+++ b/getting-started/basic.md
@@ -229,13 +229,18 @@ And, you can make your own middleware.
 
 ## Adapter
 
-There are Adapters for platform-dependent functions, e.g., handling static files.
-For example, to handle static files in Cloudflare Workers, import `hono/cloudflare-workers`.
+There are Adapters for platform-dependent functions, e.g., handling WebSocket.
+For example, to handle WebSocket in Cloudflare Workers, import `hono/cloudflare-workers`.
 
 ```ts
-import { serveStatic } from 'hono/cloudflare-workers'
+import { upgradeWebSocket } from 'hono/cloudflare-workers'
 
-app.get('/static/*', serveStatic({ root: './' }))
+app.get(
+  '/ws',
+  upgradeWebSocket((c) => {
+    // ...
+  })
+)
 ```
 
 ## Next step

--- a/getting-started/basic.md
+++ b/getting-started/basic.md
@@ -229,7 +229,7 @@ And, you can make your own middleware.
 
 ## Adapter
 
-There are Adapters for platform-dependent functions, e.g., handling WebSocket.
+There are Adapters for platform-dependent functions, e.g., handling static files or WebSocket.
 For example, to handle WebSocket in Cloudflare Workers, import `hono/cloudflare-workers`.
 
 ```ts


### PR DESCRIPTION
A deprecated function is used in the example, this PR fixes it.

Ref: #391