### PR TITLE
docs: improve text color in light mode

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -4,7 +4,7 @@
 
   --vp-c-gray: #8e8e93;
 
-  --vp-c-text-light-1: #3c3c43;
+  --vp-c-text-light-1: #1f2328;
   --vp-c-text-light-2: #454545;
   --vp-c-text-light-3: #959595;
 

--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -1,6 +1,6 @@
 :root {
   --vp-c-white: #ffffff;
-  --vp-c-black: #141414;
+  --vp-c-black: #000000;
 
   --vp-c-gray: #8e8e93;
 

--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -1,10 +1,10 @@
 :root {
   --vp-c-white: #ffffff;
-  --vp-c-black: #000000;
+  --vp-c-black: #141414;
 
   --vp-c-gray: #8e8e93;
 
-  --vp-c-text-light-1: #000000;
+  --vp-c-text-light-1: #3c3c43;
   --vp-c-text-light-2: #454545;
   --vp-c-text-light-3: #959595;
 


### PR DESCRIPTION
The text color in light mode is pure black(`#000000`), which is not easy on the eyes.
Could you please make it the black color that is also used in [VitePress](https://vitepress.dev/)?

before:
![image](https://github.com/honojs/website/assets/114303361/78093686-7a94-4916-a707-55604db0c5e0)
after:
![image](https://github.com/honojs/website/assets/114303361/f7f08184-61ae-4811-9988-c6af5538678a)