### PR TITLE
Add link to `@hono/node-ws`

### DIFF
--- a/docs/helpers/websocket.md
+++ b/docs/helpers/websocket.md
@@ -33,6 +33,8 @@ Bun.serve({
 
 :::
 
+If you use Node.js, you can use [@hono/node-ws](https://github.com/honojs/middleware/tree/main/packages/node-ws).
+
 ## `upgradeWebSocket()`
 
 `upgradeWebSocket()` returns a handler for handling WebSocket.


### PR DESCRIPTION
I added a link, `@hono/node-ws` to WebSocket helper page.
Because I found people who think Hono doesn't provide WebSocket Adapter for Node.js.