### PR TITLE
docs: improve options section

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -18,6 +18,11 @@
   --vp-c-orange-lighter: #ff9c24;
   --vp-c-orange-dark: #e07700;
   --vp-c-orange-darker: #d68e22;
+
+  --vp-c-badge-green-light: #308b58;
+  --vp-c-badge-green-light-bg: #bff8d7;
+  --vp-c-badge-green-dark: #1fd85d;
+  --vp-c-badge-green-dark-bg: #308b5769;
 }
 
 /**
@@ -72,6 +77,9 @@
   --vp-sidebar-bg-color: var(--vp-c-bg-alt);
   --vp-code-copy-code-bg: var(--vp-code-block-bg);
   --vp-code-copy-code-hover-bg: var(--vp-code-block-bg);
+
+  --vp-badge-info-text: var(--vp-c-badge-green-light);
+  --vp-badge-info-bg: var(--vp-c-badge-green-light-bg);
 }
 
 :root {
@@ -155,6 +163,9 @@
 
   --vp-code-color: var(--vp-c-text-dark-1);
   --vp-code-tab-text-color: var(--vp-c-text-dark-2);
+
+  --vp-badge-info-text: var(--vp-c-badge-green-dark);
+  --vp-badge-info-bg: var(--vp-c-badge-green-dark-bg);
 }
 
 .vp-doc h1, .vp-doc h2, .vp-doc h3, .vp-doc h4, .vp-doc h5, .vp-doc h6 {

--- a/docs/helpers/accepts.md
+++ b/docs/helpers/accepts.md
@@ -41,13 +41,12 @@ export type AcceptHeader =
   | 'Accept-Ranges'
 ```
 
-### Options
-
-- `header`: `AcceptHeader` - required
-  - The target accept header.
-- `supports`: string[] - required
-  - The header values which your application supports.
-- `default`: string - required
-  - The default values.
-- `match`?: `(accepts: Accept[], config: acceptsConfig) => string`
-  - The custom match function.
+## Options
+### <Badge type="danger" text="required" /> header: `AcceptHeader`
+The target accept header.
+### <Badge type="danger" text="required" /> supports: `string[]`
+The header values which your application supports.
+### <Badge type="danger" text="required" /> default: `string`
+The default values.
+### <Badge type="info" text="optional" /> match: `(accepts: Accept[], config: acceptsConfig) => string`
+The custom match function.

--- a/docs/helpers/accepts.md
+++ b/docs/helpers/accepts.md
@@ -42,11 +42,19 @@ export type AcceptHeader =
 ```
 
 ## Options
+
 ### <Badge type="danger" text="required" /> header: `AcceptHeader`
+
 The target accept header.
+
 ### <Badge type="danger" text="required" /> supports: `string[]`
+
 The header values which your application supports.
+
 ### <Badge type="danger" text="required" /> default: `string`
+
 The default values.
+
 ### <Badge type="info" text="optional" /> match: `(accepts: Accept[], config: acceptsConfig) => string`
+
 The custom match function.

--- a/docs/helpers/cookie.md
+++ b/docs/helpers/cookie.md
@@ -52,15 +52,15 @@ app.get('/signed-cookie', async (c) => {
 
 ### `setCookie` & `setSignedCookie`
 
-- `domain`: string
-- `expires`: Date
-- `httpOnly`: boolean
-- `maxAge`: number
-- `path`: string
-- `secure`: boolean
-- `sameSite`: `'Strict'` | `'Lax'` | `'None'`
-- `prefix`: `secure` | `'host'`
-- `partitioned`: boolean
+- domain: `string`
+- expires: `Date`
+- httpOnly: `boolean`
+- maxAge: `number`
+- path: `string`
+- secure: `boolean`
+- sameSite: `'Strict'` | `'Lax'` | `'None'`
+- prefix: `secure` | `'host'`
+- partitioned: `boolean`
 
 Example:
 
@@ -96,9 +96,9 @@ await setSignedCookie(
 
 ### `deleteCookie`
 
-- `path`: string
-- `secure`: boolean
-- `domain`: string
+- path: `string`
+- secure: `boolean`
+- domain: `string`
 
 Example:
 

--- a/docs/helpers/dev.md
+++ b/docs/helpers/dev.md
@@ -56,6 +56,9 @@ POST  /v1/posts
 ## Options
 
 ### <Badge type="info" text="optional" /> verbose: `boolean`
+
 When set to `true`, it displays verbose information.
+
 ### <Badge type="info" text="optional" /> colorize: `boolean`
+
 When set to `false`, the output will not be colored.

--- a/docs/helpers/dev.md
+++ b/docs/helpers/dev.md
@@ -53,9 +53,9 @@ GET   /v1/posts/:id
 POST  /v1/posts
 ```
 
-### Options
+## Options
 
-- `verbose`: boolean - optional
-  - When set to `true`, it displays verbose information.
-- `colorize`: boolean - optional
-  - When set to `false`, the output will not be colored.
+### <Badge type="info" text="optional" /> verbose: `boolean`
+When set to `true`, it displays verbose information.
+### <Badge type="info" text="optional" /> colorize: `boolean`
+When set to `false`, the output will not be colored.

--- a/docs/helpers/jwt.md
+++ b/docs/helpers/jwt.md
@@ -42,13 +42,14 @@ const token = await sign(payload, secret)
 ```
 
 ### Options
+<br/>
 
-- `payload`: unknown - required
-  - The JWT payload to be signed. You can include other claims like in [Payload Validation](#payload-validation).
-- `secret`: string - required
-  - The secret key used for JWT verification or signing.
-- `alg`: [AlgorithmTypes](#supported-algorithmtypes)
-  - The algorithm used for JWT signing or verification. Default is HS256.
+#### <Badge type="danger" text="required" /> payload: `unknown`
+The JWT payload to be signed. You can include other claims like in [Payload Validation](#payload-validation).
+#### <Badge type="danger" text="required" /> secret: `string`
+The secret key used for JWT verification or signing.
+#### <Badge type="info" text="optional" /> alg: [AlgorithmTypes](#supported-algorithmtypes)
+The algorithm used for JWT signing or verification. The default is HS256.
 
 ## `verify()`
 
@@ -76,13 +77,14 @@ console.log(decodedPayload)
 ```
 
 ### Options
+<br/>
 
-- `token`: string - required
-  - The JWT token to be verified.
-- `secret`: string - required
-  - The secret key used for JWT verification or signing.
-- `alg`: [AlgorithmTypes](#supported-algorithmtypes)
-  - The algorithm used for JWT signing or verification. Default is HS256.
+#### <Badge type="danger" text="required" /> token: `string`
+The JWT token to be verified.
+#### <Badge type="danger" text="required" /> secret: `string`
+The secret key used for JWT verification or signing.
+#### <Badge type="info" text="optional" /> alg: [AlgorithmTypes](#supported-algorithmtypes)
+The algorithm used for JWT signing or verification. The default is HS256.
 
 ## `decode()`
 
@@ -108,9 +110,10 @@ console.log('Decoded Payload:', payload)
 ```
 
 ### Options
+<br/>
 
-- `token`: string - required
-  - The JWT token to be decoded.
+#### <Badge type="danger" text="required" /> token: `string`
+The JWT token to be decoded.
 
 > The `decode` function allows you to inspect the header and payload of a JWT token _**without**_ performing verification. This can be useful for debugging or extracting information from JWT tokens.
 

--- a/docs/helpers/jwt.md
+++ b/docs/helpers/jwt.md
@@ -42,13 +42,19 @@ const token = await sign(payload, secret)
 ```
 
 ### Options
+
 <br/>
 
 #### <Badge type="danger" text="required" /> payload: `unknown`
+
 The JWT payload to be signed. You can include other claims like in [Payload Validation](#payload-validation).
+
 #### <Badge type="danger" text="required" /> secret: `string`
+
 The secret key used for JWT verification or signing.
+
 #### <Badge type="info" text="optional" /> alg: [AlgorithmTypes](#supported-algorithmtypes)
+
 The algorithm used for JWT signing or verification. The default is HS256.
 
 ## `verify()`
@@ -77,13 +83,19 @@ console.log(decodedPayload)
 ```
 
 ### Options
+
 <br/>
 
 #### <Badge type="danger" text="required" /> token: `string`
+
 The JWT token to be verified.
+
 #### <Badge type="danger" text="required" /> secret: `string`
+
 The secret key used for JWT verification or signing.
+
 #### <Badge type="info" text="optional" /> alg: [AlgorithmTypes](#supported-algorithmtypes)
+
 The algorithm used for JWT signing or verification. The default is HS256.
 
 ## `decode()`
@@ -110,9 +122,11 @@ console.log('Decoded Payload:', payload)
 ```
 
 ### Options
+
 <br/>
 
 #### <Badge type="danger" text="required" /> token: `string`
+
 The JWT token to be decoded.
 
 > The `decode` function allows you to inspect the header and payload of a JWT token _**without**_ performing verification. This can be useful for debugging or extracting information from JWT tokens.

--- a/docs/middleware/builtin/basic-auth.md
+++ b/docs/middleware/builtin/basic-auth.md
@@ -66,21 +66,21 @@ app.use(
 
 ## Options
 
-- `username`: string - _required_
-  - The username of the user who is authenticating
-- `password`: string - _required_
-  - The password value for the provided username to authenticate against
-- `verifyUser`: `(username: string, password: string, c: Context) => boolean | Promise<boolean>`
-  - The function to verify the user
-- `realm`: string
-  - The domain name of the realm, as part of the returned WWW-Authenticate challenge header. Default is `"Secure Area"`
-  - See: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate#directives>
-- `hashFunction`: Function
-  - A function to handle hashing for safe comparison of passwords
+### <Badge type="danger" text="required" /> username: `string`
+The username of the user who is authenticating.
+### <Badge type="danger" text="required" /> password: `string`
+The password value for the provided username to authenticate against.
+### <Badge type="info" text="optional" /> realm: `string`
+The domain name of the realm, as part of the returned WWW-Authenticate challenge header. The default is `"Secure Area"`.  
+See more: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate#directives
+### <Badge type="info" text="optional" /> hashFunction: `Function`
+A function to handle hashing for safe comparison of passwords.
+### <Badge type="info" text="optional" /> verifyUser: `(username: string, password: string, c: Context) => boolean | Promise<boolean>`
+The function to verify the user.
 
 ## More Options
 
-`...users`: { `username`: string, `password`: string }[]
+### <Badge type="info" text="optional" /> ...users: `{ username: string, password: string }[]`
 
 ## Recipes
 

--- a/docs/middleware/builtin/basic-auth.md
+++ b/docs/middleware/builtin/basic-auth.md
@@ -67,15 +67,24 @@ app.use(
 ## Options
 
 ### <Badge type="danger" text="required" /> username: `string`
+
 The username of the user who is authenticating.
+
 ### <Badge type="danger" text="required" /> password: `string`
+
 The password value for the provided username to authenticate against.
+
 ### <Badge type="info" text="optional" /> realm: `string`
+
 The domain name of the realm, as part of the returned WWW-Authenticate challenge header. The default is `"Secure Area"`.  
 See more: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate#directives
+
 ### <Badge type="info" text="optional" /> hashFunction: `Function`
+
 A function to handle hashing for safe comparison of passwords.
+
 ### <Badge type="info" text="optional" /> verifyUser: `(username: string, password: string, c: Context) => boolean | Promise<boolean>`
+
 The function to verify the user.
 
 ## More Options

--- a/docs/middleware/builtin/bearer-auth.md
+++ b/docs/middleware/builtin/bearer-auth.md
@@ -87,15 +87,26 @@ app.use(
 ## Options
 
 ### <Badge type="danger" text="required" /> token: `string` | `string[]`
+
 The string to validate the incoming bearer token against.
+
 ### <Badge type="info" text="optional" /> realm: `string`
+
 The domain name of the realm, as part of the returned WWW-Authenticate challenge header. The default is `""`.
 See more: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate#directives
+
 ### <Badge type="info" text="optional" /> prefix: `string`
+
 The prefix (or known as `schema`) for the Authorization header value. The default is `"Bearer"`.
+
 ### <Badge type="info" text="optional" /> headerName: `string`
+
 The header name. The default value is `Authorization`.
+
 ### <Badge type="info" text="optional" /> hashFunction: `Function`
+
 A function to handle hashing for safe comparison of authentication tokens.
+
 ### <Badge type="info" text="optional" /> verifyToken: `(token: string, c: Context) => boolean | Promise<boolean>`
+
 The function to verify the token.

--- a/docs/middleware/builtin/bearer-auth.md
+++ b/docs/middleware/builtin/bearer-auth.md
@@ -86,16 +86,16 @@ app.use(
 
 ## Options
 
-- `token`: string | string[] - _required_
-  - The string to validate the incoming bearer token against
-- `verifyToken`: `(token: string, c: Context) => boolean | Promise<boolean>`
-  - The function to verify the token
-- `realm`: string
-  - The domain name of the realm, as part of the returned WWW-Authenticate challenge header. Default is `""`
-  - _See:_ https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate#directives
-- `prefix`: string
-  - The prefix (or known as `schema`) for the Authorization header value. Default is `"Bearer"`
-- `headerName`: string
-  - The header name. Default is `Authorization`
-- `hashFunction`: Function
-  - A function to handle hashing for safe comparison of authentication tokens
+### <Badge type="danger" text="required" /> token: `string` | `string[]`
+The string to validate the incoming bearer token against.
+### <Badge type="info" text="optional" /> realm: `string`
+The domain name of the realm, as part of the returned WWW-Authenticate challenge header. The default is `""`.
+See more: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate#directives
+### <Badge type="info" text="optional" /> prefix: `string`
+The prefix (or known as `schema`) for the Authorization header value. The default is `"Bearer"`.
+### <Badge type="info" text="optional" /> headerName: `string`
+The header name. The default value is `Authorization`.
+### <Badge type="info" text="optional" /> hashFunction: `Function`
+A function to handle hashing for safe comparison of authentication tokens.
+### <Badge type="info" text="optional" /> verifyToken: `(token: string, c: Context) => boolean | Promise<boolean>`
+The function to verify the token.

--- a/docs/middleware/builtin/body-limit.md
+++ b/docs/middleware/builtin/body-limit.md
@@ -38,8 +38,11 @@ app.post(
 ## Options
 
 ### <Badge type="danger" text="required" /> maxSize: `number`
+
 The maximum file size of the file you want to limit. The default is `100 * 1024` - `100kb`.
+
 ### <Badge type="info" text="optional" /> onError: `OnError`
+
 The error handler to be invoked if the specified file size is exceeded.
 
 ## Usage with Bun for large requests

--- a/docs/middleware/builtin/body-limit.md
+++ b/docs/middleware/builtin/body-limit.md
@@ -37,10 +37,10 @@ app.post(
 
 ## Options
 
-- `maxSize`: number - _required_
-  - The maximum file size of the file you want to limit. The default is `100 * 1024` - `100kb`.
-- `onError`: `OnError`
-  - The error handler to be invoked if the specified file size is exceeded.
+### <Badge type="danger" text="required" /> maxSize: `number`
+The maximum file size of the file you want to limit. The default is `100 * 1024` - `100kb`.
+### <Badge type="info" text="optional" /> onError: `OnError`
+The error handler to be invoked if the specified file size is exceeded.
 
 ## Usage with Bun for large requests
 

--- a/docs/middleware/builtin/cache.md
+++ b/docs/middleware/builtin/cache.md
@@ -45,13 +45,13 @@ app.get(
 
 ## Options
 
-- `cacheName`: string | `(c: Context) => string | Promise<string>` - _required_
-  - The name of the cache. Can be used to store multiple caches with different identifiers.
-- `wait`: boolean
-  - A boolean indicating if Hono should wait for the Promise of the `cache.put` function to resolve before continuing with the request. _Required to be true for the Deno environment_. Default is `false`.
-- `cacheControl`: string
-  - A string of directives for the `Cache-Control` header. See the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) for more information. When this option is not provided, no `Cache-Control` header is added to requests.
-- `vary`: string | string[]
-  - Sets the `Vary` header in the response. If the original response header already contains a `Vary` header, the values are merged, removing any duplicates. Setting this to `*` will result in an error. For more details on the Vary header and its implications for caching strategies, refer to the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary).
-- `keyGenerator`: `(c: Context) => string | Promise<string>` -
-  - Generates keys for every request in the `cacheName` store. This can be used to cache data based on request parameters or context parameters. Default is `c.req.url`.
+### <Badge type="danger" text="required" /> cacheName: `string` | `(c: Context) => string` | `Promise<string>`
+The name of the cache. Can be used to store multiple caches with different identifiers.
+### <Badge type="info" text="optional" /> wait: `boolean`
+A boolean indicating if Hono should wait for the Promise of the `cache.put` function to resolve before continuing with the request. _Required to be true for the Deno environment_. The default is `false`.
+### <Badge type="info" text="optional" /> cacheControl: `string`
+A string of directives for the `Cache-Control` header. See the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) for more information. When this option is not provided, no `Cache-Control` header is added to requests.
+### <Badge type="info" text="optional" /> vary: `string` | `string[]`
+Sets the `Vary` header in the response. If the original response header already contains a `Vary` header, the values are merged, removing any duplicates. Setting this to `*` will result in an error. For more details on the Vary header and its implications for caching strategies, refer to the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary).
+### <Badge type="info" text="optional" /> keyGenerator: `(c: Context) => string | Promise<string>`
+Generates keys for every request in the `cacheName` store. This can be used to cache data based on request parameters or context parameters. The default is `c.req.url`.

--- a/docs/middleware/builtin/cache.md
+++ b/docs/middleware/builtin/cache.md
@@ -46,12 +46,21 @@ app.get(
 ## Options
 
 ### <Badge type="danger" text="required" /> cacheName: `string` | `(c: Context) => string` | `Promise<string>`
+
 The name of the cache. Can be used to store multiple caches with different identifiers.
+
 ### <Badge type="info" text="optional" /> wait: `boolean`
+
 A boolean indicating if Hono should wait for the Promise of the `cache.put` function to resolve before continuing with the request. _Required to be true for the Deno environment_. The default is `false`.
+
 ### <Badge type="info" text="optional" /> cacheControl: `string`
+
 A string of directives for the `Cache-Control` header. See the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) for more information. When this option is not provided, no `Cache-Control` header is added to requests.
+
 ### <Badge type="info" text="optional" /> vary: `string` | `string[]`
+
 Sets the `Vary` header in the response. If the original response header already contains a `Vary` header, the values are merged, removing any duplicates. Setting this to `*` will result in an error. For more details on the Vary header and its implications for caching strategies, refer to the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary).
+
 ### <Badge type="info" text="optional" /> keyGenerator: `(c: Context) => string | Promise<string>`
+
 Generates keys for every request in the `cacheName` store. This can be used to cache data based on request parameters or context parameters. The default is `c.req.url`.

--- a/docs/middleware/builtin/compress.md
+++ b/docs/middleware/builtin/compress.md
@@ -26,4 +26,5 @@ app.use(compress())
 ## Options
 
 ### <Badge type="info" text="optional" /> encoding: `'gzip'` | `'deflate'`
+
 The compression scheme to allow for response compression. Either `gzip` or `deflate`. If not defined, both are allowed and will be used based on the `Accept-Encoding` header. `gzip` is prioritized if this option is not provided and the client provides both in the `Accept-Encoding` header.

--- a/docs/middleware/builtin/compress.md
+++ b/docs/middleware/builtin/compress.md
@@ -25,5 +25,5 @@ app.use(compress())
 
 ## Options
 
-- `encoding`: `'gzip'` | `'deflate'`
-  - The compression scheme to allow for response compression. Either `gzip` or `deflate`. If not defined, both are allowed and will be used based on the `Accept-Encoding` header. `gzip` is prioritized if this option is not provided and the client provides both in the `Accept-Encoding` header.
+### <Badge type="info" text="optional" /> encoding: `'gzip'` | `'deflate'`
+The compression scheme to allow for response compression. Either `gzip` or `deflate`. If not defined, both are allowed and will be used based on the `Accept-Encoding` header. `gzip` is prioritized if this option is not provided and the client provides both in the `Accept-Encoding` header.

--- a/docs/middleware/builtin/cors.md
+++ b/docs/middleware/builtin/cors.md
@@ -62,15 +62,15 @@ app.use(
 
 ## Options
 
-- `origin`: string | string[] | (origin:string, c:Context) => string
-  - The value of "_Access-Control-Allow-Origin_" CORS header. You can also pass the callback function like `origin: (origin) => (origin.endsWith('.example.com') ? origin : 'http://example.com')`. Default is `*`
-- `allowMethods`: string[]
-  - The value of "_Access-Control-Allow-Methods_" CORS header. Default is `['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH']`
-- `allowHeaders`: string[]
-  - The value of "_Access-Control-Allow-Headers_" CORS header. Default is `[]`
-- `maxAge`: number
-  - The value of "_Access-Control-Max-Age_" CORS header.
-- `credentials`: boolean
-  - The value of "_Access-Control-Allow-Credentials_" CORS header.
-- `exposeHeaders`: string[]
-  - The value of "_Access-Control-Expose-Headers_" CORS header. Default is `[]`
+### <Badge type="info" text="optional" /> origin: `string` | `string[]` | `(origin:string, c:Context) => string`
+The value of "_Access-Control-Allow-Origin_" CORS header. You can also pass the callback function like `origin: (origin) => (origin.endsWith('.example.com') ? origin : 'http://example.com')`. The default is `*`.
+### <Badge type="info" text="optional" /> allowMethods: `string[]`
+The value of "_Access-Control-Allow-Methods_" CORS header. The default is `['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH']`.
+### <Badge type="info" text="optional" /> allowHeaders: `string[]`
+The value of "_Access-Control-Allow-Headers_" CORS header. The default is `[]`.
+### <Badge type="info" text="optional" /> maxAge: `number`
+The value of "_Access-Control-Max-Age_" CORS header.
+### <Badge type="info" text="optional" /> credentials: `boolean`
+The value of "_Access-Control-Allow-Credentials_" CORS header.
+### <Badge type="info" text="optional" /> exposeHeaders: `string[]`
+The value of "_Access-Control-Expose-Headers_" CORS header. The default is `[]`.

--- a/docs/middleware/builtin/cors.md
+++ b/docs/middleware/builtin/cors.md
@@ -63,14 +63,25 @@ app.use(
 ## Options
 
 ### <Badge type="info" text="optional" /> origin: `string` | `string[]` | `(origin:string, c:Context) => string`
+
 The value of "_Access-Control-Allow-Origin_" CORS header. You can also pass the callback function like `origin: (origin) => (origin.endsWith('.example.com') ? origin : 'http://example.com')`. The default is `*`.
+
 ### <Badge type="info" text="optional" /> allowMethods: `string[]`
+
 The value of "_Access-Control-Allow-Methods_" CORS header. The default is `['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH']`.
+
 ### <Badge type="info" text="optional" /> allowHeaders: `string[]`
+
 The value of "_Access-Control-Allow-Headers_" CORS header. The default is `[]`.
+
 ### <Badge type="info" text="optional" /> maxAge: `number`
+
 The value of "_Access-Control-Max-Age_" CORS header.
+
 ### <Badge type="info" text="optional" /> credentials: `boolean`
+
 The value of "_Access-Control-Allow-Credentials_" CORS header.
+
 ### <Badge type="info" text="optional" /> exposeHeaders: `string[]`
+
 The value of "_Access-Control-Expose-Headers_" CORS header. The default is `[]`.

--- a/docs/middleware/builtin/csrf.md
+++ b/docs/middleware/builtin/csrf.md
@@ -45,5 +45,5 @@ app.use(
 
 ## Options
 
-- `origin`: string | string[] | Function
-  - Specify origins.
+### <Badge type="info" text="optional" /> origin: `string` | `string[]` | `Function`
+Specify origins.

--- a/docs/middleware/builtin/csrf.md
+++ b/docs/middleware/builtin/csrf.md
@@ -46,4 +46,5 @@ app.use(
 ## Options
 
 ### <Badge type="info" text="optional" /> origin: `string` | `string[]` | `Function`
+
 Specify origins.

--- a/docs/middleware/builtin/etag.md
+++ b/docs/middleware/builtin/etag.md
@@ -41,7 +41,7 @@ app.use(
 
 ## Options
 
-- `weak`: boolean
-  - Define using or not using a [weak validation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Conditional_requests#weak_validation). If `true` is set, then `w/` is added to the prefix of the value. Default is `false`.
-- `retainedHeaders`: string[]
-  - The headers that you want to retain in the 304 Response.
+### <Badge type="info" text="optional" /> weak: `boolean`
+Define using or not using a [weak validation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Conditional_requests#weak_validation). If `true` is set, then `w/` is added to the prefix of the value. The default is `false`.
+### <Badge type="info" text="optional" /> retainedHeaders: `string[]`
+The headers that you want to retain in the 304 Response.

--- a/docs/middleware/builtin/etag.md
+++ b/docs/middleware/builtin/etag.md
@@ -42,6 +42,9 @@ app.use(
 ## Options
 
 ### <Badge type="info" text="optional" /> weak: `boolean`
+
 Define using or not using a [weak validation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Conditional_requests#weak_validation). If `true` is set, then `w/` is added to the prefix of the value. The default is `false`.
+
 ### <Badge type="info" text="optional" /> retainedHeaders: `string[]`
+
 The headers that you want to retain in the 304 Response.

--- a/docs/middleware/builtin/ip-restriction.md
+++ b/docs/middleware/builtin/ip-restriction.md
@@ -81,5 +81,3 @@ app.use(
   )
 )
 ```
-
-## Options

--- a/docs/middleware/builtin/jsx-renderer.md
+++ b/docs/middleware/builtin/jsx-renderer.md
@@ -35,8 +35,7 @@ app.get('/page/about', (c) => {
 
 ## Options
 
-### `docType`: `boolean` | `string`
-
+### <Badge type="info" text="optional" /> docType: `boolean` | `string`
 If you do not want to add a DOCTYPE at the beginning of the HTML, set the `docType` option to `false`.
 
 ```tsx
@@ -76,7 +75,7 @@ app.use(
 )
 ```
 
-### `stream`: `boolean` | `Record<string, string>`
+### <Badge type="info" text="optional" /> stream: `boolean` | `Record<string, string>`
 
 If you set it to `true` or provide a Record value, it will be rendered as a streaming response.
 

--- a/docs/middleware/builtin/jsx-renderer.md
+++ b/docs/middleware/builtin/jsx-renderer.md
@@ -36,6 +36,7 @@ app.get('/page/about', (c) => {
 ## Options
 
 ### <Badge type="info" text="optional" /> docType: `boolean` | `string`
+
 If you do not want to add a DOCTYPE at the beginning of the HTML, set the `docType` option to `false`.
 
 ```tsx

--- a/docs/middleware/builtin/jwt.md
+++ b/docs/middleware/builtin/jwt.md
@@ -73,11 +73,16 @@ app.use('/auth/*', (c, next) => {
 ## Options
 
 ### <Badge type="danger" text="required" /> secret: `string`
+
 A value of your secret key.
+
 ### <Badge type="info" text="optional" /> cookie: `string`
+
 If this value is set, then the value is retrieved from the cookie header using that value as a key, which is then validated as a token.
+
 ### <Badge type="info" text="optional" /> alg: `string`
+
 An algorithm type that is used for verifying.  
 The default is `HS256`.
 
-Available types are `HS256` | `HS384` | `HS512` | `RS256` | `RS384` | `RS512` | `PS256` | `PS384` | `PS512` | `ES256` | `ES384` | `ES512` | `EdDSA`.  
+Available types are `HS256` | `HS384` | `HS512` | `RS256` | `RS384` | `RS512` | `PS256` | `PS384` | `PS512` | `ES256` | `ES384` | `ES512` | `EdDSA`.

--- a/docs/middleware/builtin/jwt.md
+++ b/docs/middleware/builtin/jwt.md
@@ -78,6 +78,6 @@ A value of your secret key.
 If this value is set, then the value is retrieved from the cookie header using that value as a key, which is then validated as a token.
 ### <Badge type="info" text="optional" /> alg: `string`
 An algorithm type that is used for verifying.  
-The default value is `HS256`.
+The default is `HS256`.
 
 Available types are `HS256` | `HS384` | `HS512` | `RS256` | `RS384` | `RS512` | `PS256` | `PS384` | `PS512` | `ES256` | `ES384` | `ES512` | `EdDSA`.  

--- a/docs/middleware/builtin/jwt.md
+++ b/docs/middleware/builtin/jwt.md
@@ -4,7 +4,7 @@ The JWT Auth Middleware provides authentication by verifying the token with JWT.
 The middleware will check for an `Authorization` header if the `cookie` option is not set.
 
 :::info
-The Authorization header sent from the client must have a specified scheme. 
+The Authorization header sent from the client must have a specified scheme.
 
 Example: `Bearer my.token.value` or `Basic my.token.value`
 :::
@@ -72,9 +72,12 @@ app.use('/auth/*', (c, next) => {
 
 ## Options
 
-- `secret`: string - _required_
-  - A value of your secret key.
-- `cookie`: string
-  - If this value is set, then the value is retrieved from the cookie header using that value as a key, which is then validated as a token.
-- `alg`: string
-  - An algorithm type that is used for verifying. Available types are `HS256` | `HS384` | `HS512` | `RS256` | `RS384` | `RS512` | `PS256` | `PS384` | `PS512` | `ES256` | `ES384` | `ES512` | `EdDSA`. Default is `HS256`.
+### <Badge type="danger" text="required" /> secret: `string`
+A value of your secret key.
+### <Badge type="info" text="optional" /> cookie: `string`
+If this value is set, then the value is retrieved from the cookie header using that value as a key, which is then validated as a token.
+### <Badge type="info" text="optional" /> alg: `string`
+An algorithm type that is used for verifying.  
+The default value is `HS256`.
+
+Available types are `HS256` | `HS384` | `HS512` | `RS256` | `RS384` | `RS512` | `PS256` | `PS384` | `PS512` | `ES256` | `ES384` | `ES512` | `EdDSA`.  

--- a/docs/middleware/builtin/logger.md
+++ b/docs/middleware/builtin/logger.md
@@ -38,6 +38,7 @@ The Logger Middleware accepts an optional `PrintFunc` function as a parameter. T
 ## Options
 
 ### <Badge type="info" text="optional" /> fn: `PrintFunc(str: string, ...rest: string[])`
+
 - `str`: Passed by the logger.
 - `...rest`: Additional string props to be printed to console.
 

--- a/docs/middleware/builtin/logger.md
+++ b/docs/middleware/builtin/logger.md
@@ -35,11 +35,11 @@ You can also extend the middleware further by providing your own `PrintFunc` fun
 
 The Logger Middleware accepts an optional `PrintFunc` function as a parameter. This function allows you to customize the logger and add additional logs.
 
-### Options
+## Options
 
-- `PrintFunc(str: string, ...rest: string[])`: Optional function
-  - `str`: Passed by the logger.
-  - `...rest`: Additional string props to be printed to console.
+### <Badge type="info" text="optional" /> fn: `PrintFunc(str: string, ...rest: string[])`
+- `str`: Passed by the logger.
+- `...rest`: Additional string props to be printed to console.
 
 ### Example
 

--- a/docs/middleware/builtin/method-override.md
+++ b/docs/middleware/builtin/method-override.md
@@ -63,11 +63,18 @@ app.use('/posts', methodOverride({ app, query: '_method' }))
 ## Options
 
 ### <Badge type="info" text="optional" /> app: `Hono`
+
 The instance of `Hono` is used in your application.
+
 ### <Badge type="info" text="optional" /> form: `string`
+
 Form key with a value containing the method name.
 The default is `_method`.
+
 ### <Badge type="info" text="optional" /> header: `boolean`
+
 Header name with a value containing the method name.
+
 ### <Badge type="info" text="optional" /> query: `boolean`
+
 Query parameter key with a value containing the method name.

--- a/docs/middleware/builtin/method-override.md
+++ b/docs/middleware/builtin/method-override.md
@@ -62,7 +62,7 @@ app.use('/posts', methodOverride({ app, query: '_method' }))
 
 ## Options
 
-### <Badge type="info" text="optional" /> app: `Hono`
+### <Badge type="danger" text="required" /> app: `Hono`
 
 The instance of `Hono` is used in your application.
 

--- a/docs/middleware/builtin/method-override.md
+++ b/docs/middleware/builtin/method-override.md
@@ -62,12 +62,12 @@ app.use('/posts', methodOverride({ app, query: '_method' }))
 
 ## Options
 
-- `app`: `Hono`
-  - The instance of `Hono` is used in your application.
-- `form`: string
-  - Form key with a value containing the method name.
-  - The default is `_method`.
-- `header`: boolean
-  - Header name with a value containing the method name.
-- `query`: boolean
-  - Query parameter key with a value containing the method name.
+### <Badge type="info" text="optional" /> app: `Hono`
+The instance of `Hono` is used in your application.
+### <Badge type="info" text="optional" /> form: `string`
+Form key with a value containing the method name.
+The default is `_method`.
+### <Badge type="info" text="optional" /> header: `boolean`
+Header name with a value containing the method name.
+### <Badge type="info" text="optional" /> query: `boolean`
+Query parameter key with a value containing the method name.

--- a/docs/middleware/builtin/pretty-json.md
+++ b/docs/middleware/builtin/pretty-json.md
@@ -41,4 +41,5 @@ app.get('/', (c) => {
 ## Options
 
 ### <Badge type="info" text="optional" /> space: `number`
+
 Number of spaces for indentation. The default is `2`.

--- a/docs/middleware/builtin/pretty-json.md
+++ b/docs/middleware/builtin/pretty-json.md
@@ -40,5 +40,5 @@ app.get('/', (c) => {
 
 ## Options
 
-- `space`
-  - Number of spaces for indentation. Default is `2`.
+### <Badge type="info" text="optional" /> space: `number`
+Number of spaces for indentation. The default is `2`.

--- a/docs/middleware/builtin/request-id.md
+++ b/docs/middleware/builtin/request-id.md
@@ -35,9 +35,14 @@ const app = new Hono<{
 
 ## Options
 
-- `limitLength`: number
-  - The maximum length of the request ID. The default is `255`.
-- `headerName`: string
-  - The header name used for the request ID. The default is `X-Request-Id`.
-- `generator`: `(c: Context) => string`
-  - The request ID generation function. By default, it uses `crypto.randomUUID()`.
+### <Badge type="info" text="optional" /> limitLength: `number`
+
+The maximum length of the request ID. The default is `255`.
+
+### <Badge type="info" text="optional" /> headerName: `string`
+
+The header name used for the request ID. The default is `X-Request-Id`.
+
+### <Badge type="info" text="optional" /> generator: `(c: Context) => string`
+
+The request ID generation function. By default, it uses `crypto.randomUUID()`.

--- a/docs/middleware/builtin/timing.md
+++ b/docs/middleware/builtin/timing.md
@@ -67,18 +67,28 @@ app.use(
 ## Options
 
 ### <Badge type="info" text="optional" /> total: `boolean`
+
 Show the total response time. The default is `true`.
+
 ### <Badge type="info" text="optional" /> enabled: `boolean` | `(c: Context) => boolean`
+
 Whether timings should be added to the headers or not. The default is `true`.
+
 ### <Badge type="info" text="optional" /> totalDescription: `boolean`
+
 Description for the total response time. The default is `Total Response Time`.
+
 ### <Badge type="info" text="optional" /> autoEnd: `boolean`
+
 If `startTime()` should end automatically at the end of the request.
 If disabled, not manually ended timers will not be shown.
+
 ### <Badge type="info" text="optional" /> crossOrigin: `boolean` | `string` | `(c: Context) => boolean | string`
+
 The origin this timings header should be readable.
-  - If false, only from current origin.
-  - If true, from all origin.
-  - If string, from this domain(s). Multiple domains must be separated with a comma.
+
+- If false, only from current origin.
+- If true, from all origin.
+- If string, from this domain(s). Multiple domains must be separated with a comma.
 
 The default is `false`. See more [docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Timing-Allow-Origin).

--- a/docs/middleware/builtin/timing.md
+++ b/docs/middleware/builtin/timing.md
@@ -66,19 +66,19 @@ app.use(
 
 ## Options
 
-- `total`: boolean
-  - Show the total response time. Default is `true`.
-- `enabled`: boolean | `(c: Context) => boolean`
-  - Whether timings should be added to the headers or not. Default is `true`.
-- `totalDescription`: boolean
-  - Description for the total response time. Default is `Total Response Time`.
-- `autoEnd`: boolean
-  - If `startTime()` should end automatically at the end of the request.
-  - If disabled, not manually ended timers will not be shown.
-- `crossOrigin`: boolean | string | `(c: Context) => boolean | string`
-  - The origin this timings header should be readable.
-    - If false, only from current origin.
-    - If true, from all origin.
-    - If string, from this domain(s). Multiple domains must be separated with a comma.
-  - See [docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Timing-Allow-Origin).
-  - Default is `false`
+### <Badge type="info" text="optional" /> total: `boolean`
+Show the total response time. The default is `true`.
+### <Badge type="info" text="optional" /> enabled: `boolean` | `(c: Context) => boolean`
+Whether timings should be added to the headers or not. The default is `true`.
+### <Badge type="info" text="optional" /> totalDescription: `boolean`
+Description for the total response time. The default is `Total Response Time`.
+### <Badge type="info" text="optional" /> autoEnd: `boolean`
+If `startTime()` should end automatically at the end of the request.
+If disabled, not manually ended timers will not be shown.
+### <Badge type="info" text="optional" /> crossOrigin: `boolean` | `string` | `(c: Context) => boolean | string`
+The origin this timings header should be readable.
+  - If false, only from current origin.
+  - If true, from all origin.
+  - If string, from this domain(s). Multiple domains must be separated with a comma.
+
+The default is `false`. See more [docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Timing-Allow-Origin).


### PR DESCRIPTION
closes #403

I made a few changes from the design proposed in the issue.
I set types as a code block and placed either required or optional at the beginning.
Basically, types are expressed as blocks of code, so I think that's natural.

Light
![image](https://github.com/honojs/website/assets/114303361/68b7a994-56c1-4eab-8313-a938e4770c9a)

Dark
![image](https://github.com/honojs/website/assets/114303361/2a46cb17-b1dd-48db-8369-836362db0f74)

If you have any opinions about the design, please feel free to comment.