### PR TITLE
Add Deno Deploy compresses the body response

### DIFF
--- a/docs/middleware/builtin/compress.md
+++ b/docs/middleware/builtin/compress.md
@@ -3,7 +3,7 @@
 This middleware compresses the response body, according to `Accept-Encoding` request header.
 
 ::: info
-**Note**: On Cloudflare Workers, the response body will be compressed automatically, so there is no need to use this middleware.
+**Note**: On Cloudflare Workers and Deno Deploy, the response body will be compressed automatically, so there is no need to use this middleware.
 
 **Bun**: This middleware uses `CompressionStream` which is not yet supported in bun.
 :::


### PR DESCRIPTION
Add Deno Deploy to the list of services that already compress the body response.

See https://docs.deno.com/deploy/api/compression/