### PR TITLE
fix pylon example

### DIFF
--- a/examples/pylon.md
+++ b/examples/pylon.md
@@ -111,8 +111,8 @@ export default defineService({
     user: User.getById,
   },
   Mutation: {
-    createPost: (userId: string, title: string, content: string) => {
-      const user = User.getById(userId)
+    createPost: async (userId: string, title: string, content: string) => {
+      const user = await User.getById(userId)
       return user.$createPost(title, content)
     },
   },


### PR DESCRIPTION
Added async await to `createPost` because the following error occured.

> Property '$createPost' does not exist on type `Promise<User>`.