### PR TITLE
docs (rpc): multiple parameters

### DIFF
--- a/docs/guides/rpc.md
+++ b/docs/guides/rpc.md
@@ -176,6 +176,41 @@ const res = await client.posts[':id'].$get({
 })
 ```
 
+### Multiple Parameters
+
+Handle routes with multiple parameters.
+
+```ts
+const route = app.get(
+  '/posts/:postId/:authorId',
+  zValidator(
+    'query',
+    z.object({
+      page: z.string().optional(),
+    })
+  ),
+  (c) => {
+    // ...
+    return c.json({
+      title: 'Night',
+      body: 'Time to sleep',
+    })
+  }
+)
+```
+
+Add multiple `['']` to specify params in path.
+
+```ts
+const res = await client.posts[':postId'][':authorId'].$get({
+  param: {
+    postId: '123',
+    authorId: '456',
+  },
+  query: {},
+})
+```
+
 ## Headers
 
 You can append the headers to the request.


### PR DESCRIPTION
Add a section under `Path Parameters`, to show how to call API with endpoints like: `/posts/:postId/:authorId` using hono client.