### PR TITLE
docs: remove an expired link of serveStatic example for cloudflare-workers

### DIFF
--- a/docs/getting-started/cloudflare-workers.md
+++ b/docs/getting-started/cloudflare-workers.md
@@ -201,8 +201,6 @@ app.get('/static/*', serveStatic({ root: './', manifest }))
 app.get('/favicon.ico', serveStatic({ path: './favicon.ico' }))
 ```
 
-See [Example](https://github.com/honojs/examples/tree/main/serve-static).
-
 ### `rewriteRequestPath`
 
 If you want to map `http://localhost:8787/static/*` to `./assets/statics`, you can use the `rewriteRequestPath` option:


### PR DESCRIPTION
I found that an example for `serveStatic` for cloudflare-workers does not exist in the honojs/examples repo, so I deleted this line.

```md
See [Example](https://github.com/honojs/examples/tree/main/serve-static).
```