### PR TITLE
Add link to test helper

### DIFF
--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -10,6 +10,8 @@ In this section, let's test with Cloudflare Workers and Jest.
 All you do is create a Request and pass it to the Hono application to validate the Response.
 And, you can use `app.request` the useful method.
 
+> For a typed test client see the [testing helper](/docs/helpers/testing).
+
 For example, consider an application that provides the following REST API.
 
 ```ts

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -10,7 +10,9 @@ In this section, let's test with Cloudflare Workers and Jest.
 All you do is create a Request and pass it to the Hono application to validate the Response.
 And, you can use `app.request` the useful method.
 
-> For a typed test client see the [testing helper](/docs/helpers/testing).
+::: tip
+For a typed test client see the [testing helper](/docs/helpers/testing).
+:::
 
 For example, consider an application that provides the following REST API.
 


### PR DESCRIPTION
This adds a link to the test helper in the testing guide. I didn't find the helper until after using `app.request` for a few tests.