### PR TITLE
docs(middleware): add instructions for extending context

### DIFF
--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -189,6 +189,27 @@ app.use('*', async (c, next) => {
 })
 ```
 
+### Extending the Context in Middleware
+
+To extend the context inside middleware, use `c.set`. You can make this type-safe by passing a `{ Variables: { yourVariable: YourVariableType } }` generic argument to the `createMiddleware` function.
+
+```ts
+import { createMiddleware } from 'hono/factory'
+
+const echoMiddleware = createMiddleware<{
+  Variables: {
+    echo: (str: string) => string
+  }
+}>(async (c, next) => {
+  c.set('echo', (str) => str)
+  await next()
+})
+
+app.get('/echo', echoMiddleware, (c) => {
+  return c.text(c.var.echo('Hello!'))
+})
+```
+
 ## Third-party Middleware
 
 Built-in middleware does not depend on external modules, but third-party middleware can depend on third-party libraries.


### PR DESCRIPTION
Spent an hour trying to figure this out, then found the answer buried in [this discussion](https://github.com/honojs/hono/issues/414#issuecomment-1800878459). Looks like there's still ongoing discussion re: the ergonomics of this, but I figured it'd be useful to surface the current method.