### PR TITLE
fix: incorrect function notation in ssgParams section

### DIFF
--- a/docs/helpers/ssg.md
+++ b/docs/helpers/ssg.md
@@ -245,7 +245,7 @@ Introducing built-in middleware that supports SSG.
 
 ### ssgParams
 
-You can use an API like `generateStaticPaths` of Next.js.
+You can use an API like `generateStaticParams` of Next.js.
 
 Example:
 


### PR DESCRIPTION
## description

There is no function named `generateStaticPaths`, according to the Next.js docs. So, based on the `ssgParams` example of the Hono, I correct it to `generateStaticParams`). (ref: [Functions: generateStaticParams | Next.js](https://nextjs.org/docs/app/api-reference/functions/generate-static-params))