### PR TITLE
docs(cache): can be used with Deno Deploy

### DIFF
--- a/docs/middleware/builtin/cache.md
+++ b/docs/middleware/builtin/cache.md
@@ -1,10 +1,10 @@
 # Cache Middleware
 
-The Cache middleware uses the Web Standards' [Cache API](https://developer.mozilla.org/en-US/docs/Web/API/Cache). It caches a given response according to the `Cache-Control` headers.
+The Cache middleware uses the Web Standards' [Cache API](https://developer.mozilla.org/en-US/docs/Web/API/Cache).
 
-The Cache middleware currently supports Cloudflare Workers projects using custom domains and Deno projects using [Deno 1.26+](https://github.com/denoland/deno/releases/tag/v1.26.0).
+The Cache middleware currently supports Cloudflare Workers projects using custom domains and Deno projects using [Deno 1.26+](https://github.com/denoland/deno/releases/tag/v1.26.0). Also available with Deno Deploy.
 
-Please be aware that the Cache API is not currently supported by Deno Deploy. The `caches` variable, which is part of the Cache API, may not be available in the Deno Deploy environment.
+Cloudflare Workers respects the `Cache-Control` header and return cached responses. For details, refer to [Cache on Cloudflare Docs](https://developers.cloudflare.com/workers/runtime-apis/cache/). Deno does not respect headers, so if you need to update the cache, you will need to implement your own mechanism.
 
 See [Usage](#usage) below for instructions on each platform.
 


### PR DESCRIPTION
Add that cache middleware is can be used in Deno Deploy.
Ref: https://deno.com/blog/deploy-cache-api

In addition, the `Cache-Control` header is only respected by Cloudflare Workers, so state that.