### PR TITLE
Add category for third-party middleware

### DIFF
--- a/docs/middleware/third-party.md
+++ b/docs/middleware/third-party.md
@@ -3,32 +3,43 @@
 Third-party middleware refers to middleware not bundled within the Hono package.
 Most of this middleware leverages external libraries.
 
-- [ArkType validator](https://github.com/honojs/middleware/tree/main/packages/arktype-validator)
+### Authentication
+
 - [Auth.js(Next Auth)](https://github.com/honojs/middleware/tree/main/packages/auth-js)
-- [Bun Transpiler](https://github.com/honojs/middleware/tree/main/packages/bun-transpiler)
 - [Clerk Auth](https://github.com/honojs/middleware/tree/main/packages/clerk-auth)
+- [OAuth Providers](https://github.com/honojs/middleware/tree/main/packages/oauth-providers)
+- [OIDC Auth](https://github.com/honojs/middleware/tree/main/packages/oidc-auth)
+- [Firebase Auth](https://github.com/honojs/middleware/tree/main/packages/firebase-auth)
+- [Verify RSA JWT (JWKS)](https://github.com/wataruoguchi/verify-rsa-jwt-cloudflare-worker)
+
+### Validators
+
+- [ArkType validator](https://github.com/honojs/middleware/tree/main/packages/arktype-validator)
 - [Effect Schema Validator](https://github.com/honojs/middleware/tree/main/packages/effect-validator)
+- [TypeBox Validator](https://github.com/honojs/middleware/tree/main/packages/typebox-validator)
+- [Typia Validator](https://github.com/honojs/middleware/tree/main/packages/typia-validator)
+- [unknownutil Validator](https://github.com/ryoppippi/hono-unknownutil-validator)
+- [Valibot Validator](https://github.com/honojs/middleware/tree/main/packages/valibot-validator)
+- [Zod Validator](https://github.com/honojs/middleware/tree/main/packages/zod-validator)
+
+### OpenAPI
+
+- [Zod OpenAPI](https://github.com/honojs/middleware/tree/main/packages/zod-openapi)
+- [Scalar API Reference](https://github.com/scalar/scalar/tree/main/packages/hono-api-reference)
+- [Swagger UI](https://github.com/honojs/middleware/tree/main/packages/swagger-ui)
+
+### Others
+
+- [Bun Transpiler](https://github.com/honojs/middleware/tree/main/packages/bun-transpiler)
 - [esbuild Transpiler](https://github.com/honojs/middleware/tree/main/packages/esbuild-transpiler)
 - [ESLint Config](https://github.com/honojs/middleware/tree/main/packages/eslint-config)
-- [Firebase Auth](https://github.com/honojs/middleware/tree/main/packages/firebase-auth)
 - [GraphQL Server](https://github.com/honojs/middleware/tree/main/packages/graphql-server)
 - [Hono Rate Limiter](https://github.com/rhinobase/hono-rate-limiter)
 - [Node WebSocket Helper](https://github.com/honojs/middleware/tree/main/packages/node-ws)
-- [OAuth Providers](https://github.com/honojs/middleware/tree/main/packages/oauth-providers)
-- [OIDC Auth](https://github.com/honojs/middleware/tree/main/packages/oidc-auth)
 - [Prometheus Metrics](https://github.com/honojs/middleware/tree/main/packages/prometheus)
 - [Qwik City](https://github.com/honojs/middleware/tree/main/packages/qwik-city)
 - [React Compatibility](https://github.com/honojs/middleware/tree/main/packages/react-compat)
 - [React Renderer](https://github.com/honojs/middleware/tree/main/packages/react-renderer)
 - [RONIN (Database)](https://github.com/ronin-co/hono-client)
-- [Scalar API Reference](https://github.com/scalar/scalar/tree/main/packages/hono-api-reference)
 - [Sentry](https://github.com/honojs/middleware/tree/main/packages/sentry)
-- [Swagger UI](https://github.com/honojs/middleware/tree/main/packages/swagger-ui)
 - [tRPC Server](https://github.com/honojs/middleware/tree/main/packages/trpc-server)
-- [TypeBox Validator](https://github.com/honojs/middleware/tree/main/packages/typebox-validator)
-- [Typia Validator](https://github.com/honojs/middleware/tree/main/packages/typia-validator)
-- [unknownutil Validator](https://github.com/ryoppippi/hono-unknownutil-validator)
-- [Valibot Validator](https://github.com/honojs/middleware/tree/main/packages/valibot-validator)
-- [Verify RSA JWT (JWKS)](https://github.com/wataruoguchi/verify-rsa-jwt-cloudflare-worker)
-- [Zod OpenAPI](https://github.com/honojs/middleware/tree/main/packages/zod-openapi)
-- [Zod Validator](https://github.com/honojs/middleware/tree/main/packages/zod-validator)

--- a/docs/middleware/third-party.md
+++ b/docs/middleware/third-party.md
@@ -32,7 +32,6 @@ Most of this middleware leverages external libraries.
 
 - [Bun Transpiler](https://github.com/honojs/middleware/tree/main/packages/bun-transpiler)
 - [esbuild Transpiler](https://github.com/honojs/middleware/tree/main/packages/esbuild-transpiler)
-- [ESLint Config](https://github.com/honojs/middleware/tree/main/packages/eslint-config)
 - [GraphQL Server](https://github.com/honojs/middleware/tree/main/packages/graphql-server)
 - [Hono Rate Limiter](https://github.com/rhinobase/hono-rate-limiter)
 - [Node WebSocket Helper](https://github.com/honojs/middleware/tree/main/packages/node-ws)


### PR DESCRIPTION
This PR includes the following categories for the page listing third-party middleware:  
-  Authentication  
-  Validators  
-  OpenAPI  

What can be discussed is the order of these categories; for now, it is organized by the number of entries in each category.
 We can also add more categories, but I have not found any meaningful groups for the rest of the list.