### PR TITLE
Update cloudflare-pages.md

### DIFF
--- a/docs/getting-started/cloudflare-pages.md
+++ b/docs/getting-started/cloudflare-pages.md
@@ -181,7 +181,7 @@ MY_NAME = "Hono"
 Next, make the KV. Run the following `wrangler` command:
 
 ```sh
-wrangler kv:namespace create MY_KV --preview
+wrangler kv namespace create MY_KV --preview
 ```
 
 Note down the `preview_id` as the following output:


### PR DESCRIPTION
When I executed the command to create a KV namespace using the following shell command:

```
wrangler kv:namespace create MY_KV --preview
```

I received the following warning:

```
▲ [WARNING] The `wrangler kv:namespace` command is deprecated and will be removed in a future major version. Please use `wrangler kv namespace` instead which behaves the same.
```

To address this, I removed the colon ":" between "kv" and "namespace".