### PR TITLE
Update best-practices.md

### DIFF
--- a/docs/guides/best-practices.md
+++ b/docs/guides/best-practices.md
@@ -110,3 +110,20 @@ app.route('/books', books)
 
 export default app
 ```
+## Declarative Approach for RPC Type Inference
+
+Use a declarative approach when defining routes for better type inference in RPC scenarios.
+
+```ts
+// authors.ts
+const app = new Hono()
+  .get('/', (c) => c.json('list authors'))
+  .post('/', (c) => c.json('create an author', 201))
+  .get('/:id', (c) => c.json(`get ${c.req.param('id')}`))
+
+// books.ts
+const app = new Hono()
+  .get('/', (c) => c.json('list books'))
+  .post('/', (c) => c.json('create a book', 201))
+  .get('/:id', (c) => c.json(`get ${c.req.param('id')}`))
+```


### PR DESCRIPTION
The routes declared in separate files cannot be imperative for RPC inference, so I added that point under best practice while using RPC. I had this issue and it took me some time to figure out, I hope this will help other users as well