### PR TITLE
 Fixed incorrect description of __Host- prefix in cookie.md

### DIFF
--- a/docs/helpers/cookie.md
+++ b/docs/helpers/cookie.md
@@ -174,6 +174,6 @@ The cookie helper will throw an `Error` when parsing cookies under the following
 - The cookie name starts with `__Secure-`, but `secure` option is not set.
 - The cookie name starts with `__Host-`, but `secure` option is not set.
 - The cookie name starts with `__Host-`, but `path` is not `/`.
-- The cookie name starts with `__Host-`, but `domain` is not set.
+- The cookie name starts with `__Host-`, but `domain` not set.
 - The `maxAge` option value is greater than 400 days.
 - The `expires` option value is 400 days later than the current time.

--- a/docs/helpers/cookie.md
+++ b/docs/helpers/cookie.md
@@ -174,6 +174,6 @@ The cookie helper will throw an `Error` when parsing cookies under the following
 - The cookie name starts with `__Secure-`, but `secure` option is not set.
 - The cookie name starts with `__Host-`, but `secure` option is not set.
 - The cookie name starts with `__Host-`, but `path` is not `/`.
-- The cookie name starts with `__Host-`, but `domain` not set.
+- The cookie name starts with `__Host-`, but `domain` is set.
 - The `maxAge` option value is greater than 400 days.
 - The `expires` option value is 400 days later than the current time.


### PR DESCRIPTION
### Fixed inconsistencies with the implementation in the "Following the best practices" section.

#### Comments in code [hono/src/helper/cookie/index.ts] :
```js
// Cookie names prefixed with __Host- can be used only if they are set with the secure attribute, must have a path of / (meaning any path at the host)
// and must not have a Domain attribute.
```

#### in website : 
> Hono is following the best practices. The cookie helper will throw an Error when parsing cookies under the following conditions:
> - The cookie name starts with __Host-, but path is not /.
> - The cookie name starts with __Host-, but domain is ~***not***~ set.