### PR TITLE
docs: update the slogan

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from 'vitepress'
 import type { DefaultTheme } from 'vitepress'
-import { groupIconMdPlugin, groupIconVitePlugin } from 'vitepress-plugin-group-icons'
-
+import {
+  groupIconMdPlugin,
+  groupIconVitePlugin,
+} from 'vitepress-plugin-group-icons'
 
 const sidebars = (): DefaultTheme.SidebarItem[] => [
   {
@@ -155,7 +157,10 @@ const sidebars = (): DefaultTheme.SidebarItem[] => [
       { text: 'Cache', link: '/docs/middleware/builtin/cache' },
       { text: 'Combine', link: '/docs/middleware/builtin/combine' },
       { text: 'Compress', link: '/docs/middleware/builtin/compress' },
-      { text: 'Context Storage', link: '/docs/middleware/builtin/context-storage' },
+      {
+        text: 'Context Storage',
+        link: '/docs/middleware/builtin/context-storage',
+      },
       { text: 'CORS', link: '/docs/middleware/builtin/cors' },
       {
         text: 'CSRF Protection',
@@ -280,7 +285,7 @@ export default defineConfig({
   lang: 'en-US',
   title: 'Hono',
   description:
-    'Ultrafast web framework for Cloudflare Workers, Fastly Compute, Deno, Bun, Vercel, Node.js, and others. Fast, but not only fast.',
+    'Web framework built on Web Standards for Cloudflare Workers, Fastly Compute, Deno, Bun, Vercel, Node.js, and others. Fast, but not only fast.',
   lastUpdated: true,
   ignoreDeadLinks: true,
   cleanUrls: true,
@@ -356,9 +361,9 @@ export default defineConfig({
     plugins: [
       groupIconVitePlugin({
         customIcon: {
-          cloudflare: 'logos:cloudflare-workers-icon'
-        }
-      })
+          cloudflare: 'logos:cloudflare-workers-icon',
+        },
+      }),
     ],
-  }
+  },
 })

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-title: Hono - Ultrafast web framework for the Edges
+title: Hono - Web framework built on Web Standards
 titleTemplate: ':title'
 ---
 

--- a/index.md
+++ b/index.md
@@ -1,12 +1,12 @@
 ---
-title: Hono - Ultrafast web framework for the Edges
+title: Hono - Web framework built on Web Standards
 titleTemplate: ':title'
 head:
   - [
       'meta',
       {
         property: 'og:description',
-        content: 'Hono is a small, simple, and ultrafast web framework for the Edges. It works on Cloudflare Workers, Fastly Compute, Deno, Bun, Vercel, Netlify, AWS Lambda, Lambda@Edge, and Node.js. Fast, but not only fast.',
+        content: 'Hono is a small, simple, and ultrafast web framework built on Web Standards. It works on Cloudflare Workers, Fastly Compute, Deno, Bun, Vercel, Netlify, AWS Lambda, Lambda@Edge, and Node.js. Fast, but not only fast.',
       },
     ]
 layout: home


### PR DESCRIPTION
In this PR, update our slogan. The old one had "ultrafast" in it. It's not doubt, but currently, we have to say "build on Web Standards" rather than "fast."