### PR TITLE
feat: add Twoslash to show TypeScript types

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -4,6 +4,7 @@ import {
   groupIconMdPlugin,
   groupIconVitePlugin,
 } from 'vitepress-plugin-group-icons'
+import { transformerTwoslash } from '@shikijs/vitepress-twoslash'
 
 const sidebars = (): DefaultTheme.SidebarItem[] => [
   {
@@ -301,6 +302,9 @@ export default defineConfig({
     config(md) {
       md.use(groupIconMdPlugin)
     },
+    codeTransformers: [
+      transformerTwoslash()
+    ]
   },
   themeConfig: {
     logo: '/images/logo-small.png',

--- a/.vitepress/theme/index.js
+++ b/.vitepress/theme/index.js
@@ -1,5 +1,0 @@
-import DefaultTheme from 'vitepress/theme'
-import './custom.css'
-import 'virtual:group-icons.css'
-
-export default DefaultTheme

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -1,0 +1,13 @@
+import DefaultTheme from 'vitepress/theme'
+import type { EnhanceAppContext } from 'vitepress'
+import './custom.css'
+import 'virtual:group-icons.css'
+import '@shikijs/vitepress-twoslash/style.css'
+import ThoslashFloatingVue from '@shikijs/vitepress-twoslash/client'
+
+export default {
+  extends: DefaultTheme,
+  enhanceApp({ app }: EnhanceAppContext) {
+    app.use(ThoslashFloatingVue)
+  },
+}

--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -6,10 +6,16 @@ To handle Request and Response, you can use `Context` object.
 
 `req` is the instance of HonoRequest.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.get('/hello', (c) => {
   const userAgent = c.req.header('User-Agent')
-  ...
+  // ...
+  // ---cut-start---
+  return c.text(`Hello, ${userAgent}`)
+  // ---cut-end---
 })
 ```
 
@@ -24,7 +30,10 @@ This can also be set in `c.text()`, `c.json()` and so on.
 **Note**: When returning Text or HTML, it is recommended to use `c.text()` or `c.html()`.
 :::
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.get('/welcome', (c) => {
   // Set headers
   c.header('X-Message', 'Hello!')
@@ -40,7 +49,10 @@ app.get('/welcome', (c) => {
 
 You can also write the following.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.get('/welcome', (c) => {
   return c.body('Thank you for coming', 201, {
     'X-Message': 'Hello!',
@@ -51,7 +63,7 @@ app.get('/welcome', (c) => {
 
 The Response is the same as below.
 
-```ts
+```ts twoslash
 new Response('Thank you for coming', {
   status: 201,
   headers: {
@@ -65,7 +77,10 @@ new Response('Thank you for coming', {
 
 Render text as `Content-Type:text/plain`.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.get('/say', (c) => {
   return c.text('Hello!')
 })
@@ -75,7 +90,10 @@ app.get('/say', (c) => {
 
 Render JSON as `Content-Type:application/json`.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.get('/api', (c) => {
   return c.json({ message: 'Hello!' })
 })
@@ -85,7 +103,10 @@ app.get('/api', (c) => {
 
 Render HTML as `Content-Type:text/html`.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.get('/', (c) => {
   return c.html('<h1>Hello! Hono!</h1>')
 })
@@ -95,7 +116,10 @@ app.get('/', (c) => {
 
 Return the `Not Found` Response.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.get('/notfound', (c) => {
   return c.notFound()
 })
@@ -105,7 +129,10 @@ app.get('/notfound', (c) => {
 
 Redirect, default status code is `302`.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.get('/redirect', (c) => {
   return c.redirect('/')
 })
@@ -116,7 +143,10 @@ app.get('/redirect-permanently', (c) => {
 
 ## res
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 // Response object
 app.use('/', async (c, next) => {
   await next()
@@ -128,7 +158,10 @@ app.use('/', async (c, next) => {
 
 Get and set arbitrary key-value pairs, with a lifetime of the current request. This allows passing specific values between middleware or from middleware to route handlers.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono<{ Variables: { message: string } }>()
+// ---cut---
 app.use(async (c, next) => {
   c.set('message', 'Hono is cool!!')
   await next()
@@ -142,7 +175,9 @@ app.get('/', (c) => {
 
 Pass the `Variables` as Generics to the constructor of `Hono` to make it type-safe.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+// ---cut---
 type Variables = {
   message: string
 }
@@ -156,14 +191,20 @@ The value of `c.set` / `c.get` are retained only within the same request. They c
 
 You can also access the value of a variable with `c.var`.
 
-```ts
+```ts twoslash
+import type { Context } from 'hono'
+declare const c: Context
+// ---cut---
 const result = c.var.client.oneMethod()
 ```
 
 If you want to create the middleware which provides a custom method,
 write like the following:
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+import { createMiddleware } from 'hono/factory'
+// ---cut---
 type Env = {
   Variables: {
     echo: (str: string) => string
@@ -185,7 +226,16 @@ app.get('/echo', echoMiddleware, (c) => {
 If you want to use the middleware in multiple handlers, you can use `app.use()`.
 Then, you have to pass the `Env` as Generics to the constructor of `Hono` to make it type-safe.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+import type { MiddlewareHandler } from 'hono/types'
+declare const echoMiddleware: MiddlewareHandler
+type Env = {
+  Variables: {
+    echo: (str: string) => string
+  }
+}
+// ---cut---
 const app = new Hono<Env>()
 
 app.use(echoMiddleware)
@@ -199,7 +249,12 @@ app.get('/echo', (c) => {
 
 You can set a layout using `c.setRenderer()` within a custom middleware.
 
-```tsx
+```tsx twoslash
+/** @jsx jsx */
+/** @jsxImportSource hono/jsx */
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.use(async (c, next) => {
   c.setRenderer((content) => {
     return c.html(
@@ -216,7 +271,10 @@ app.use(async (c, next) => {
 
 Then, you can utilize `c.render()` to create responses within this layout.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.get('/', (c) => {
   return c.render('Hello!')
 })
@@ -281,19 +339,33 @@ app.get('/pages/my-hobbies', (c) => {
 
 ## executionCtx
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono<{
+  Bindings: {
+    KV: any
+  }
+}>()
+declare const key: string
+declare const data: string
+// ---cut---
 // ExecutionContext object
 app.get('/foo', async (c) => {
   c.executionCtx.waitUntil(
     c.env.KV.put(key, data)
   )
-  ...
+  // ...
 })
 ```
 
 ## event
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+declare const key: string
+declare const data: string
+type KVNamespace = any
+// ---cut---
 // Type definition to make type inference
 type Bindings = {
   MY_KV: KVNamespace
@@ -307,7 +379,7 @@ app.get('/foo', async (c) => {
   c.event.waitUntil(
     c.env.MY_KV.put(key, data)
   )
-  ...
+  // ...
 })
 ```
 
@@ -316,7 +388,10 @@ app.get('/foo', async (c) => {
 In Cloudflare Workers Environment variables, secrets, KV namespaces, D1 database, R2 bucket etc. that are bound to a worker are known as bindings.
 Regardless of type, bindings are always available as global variables and can be accessed via the context `c.env.BINDING_KEY`.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+type KVNamespace = any
+// ---cut---
 // Type definition to make type inference
 type Bindings = {
   MY_KV: KVNamespace
@@ -325,7 +400,7 @@ type Bindings = {
 const app = new Hono<{ Bindings: Bindings }>()
 
 // Environment object for Cloudflare Workers
-app.get('/', (c) => {
+app.get('/', async (c) => {
   c.env.MY_KV.get('my-key')
   // ...
 })
@@ -336,7 +411,10 @@ app.get('/', (c) => {
 If the Handler throws an error, the error object is placed in `c.error`.
 You can access it in your middleware.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.use(async (c, next) => {
   await next()
   if (c.error) {
@@ -359,7 +437,9 @@ declare module 'hono' {
 
 You can then utilize this in your middleware:
 
-```ts
+```ts twoslash
+import { createMiddleware } from 'hono/factory'
+// ---cut---
 const mw = createMiddleware(async (c, next) => {
   c.set('result', 'some values') // result is a string
   await next()
@@ -368,9 +448,13 @@ const mw = createMiddleware(async (c, next) => {
 
 In a handler, the variable is inferred as the proper type:
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono<{ Variables: { result: string } }>()
+// ---cut---
 app.get('/', (c) => {
   const val = c.get('result') // val is a string
-  //...
+  // ...
+  return c.json({ result: val })
 })
 ```

--- a/docs/api/exception.md
+++ b/docs/api/exception.md
@@ -6,7 +6,11 @@ When a fatal error occurs, such as authentication failure, an HTTPException must
 
 This example throws an HTTPException from the middleware.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+declare const authorized: boolean
+// ---cut---
 import { HTTPException } from 'hono/http-exception'
 
 // ...
@@ -22,13 +26,16 @@ app.post('/auth', async (c, next) => {
 
 You can specify the response to be returned back to the user.
 
-```ts
+```ts twoslash
+import { HTTPException } from 'hono/http-exception'
+
 const errorResponse = new Response('Unauthorized', {
   status: 401,
   headers: {
     Authenticate: 'error="invalid_token"',
   },
 })
+
 throw new HTTPException(401, { res: errorResponse })
 ```
 
@@ -36,7 +43,10 @@ throw new HTTPException(401, { res: errorResponse })
 
 You can handle the thrown HTTPException with `app.onError`.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 import { HTTPException } from 'hono/http-exception'
 
 // ...
@@ -46,7 +56,10 @@ app.onError((err, c) => {
     // Get the custom response
     return err.getResponse()
   }
-  //...
+  // ...
+  // ---cut-start---
+  return c.text('Error')
+  // ---cut-end---
 })
 ```
 
@@ -54,7 +67,13 @@ app.onError((err, c) => {
 
 The `cause` option is available to add a [`cause`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) data.
 
-```ts
+```ts twoslash
+import { Hono, Context } from 'hono'
+import { HTTPException } from 'hono/http-exception'
+const app = new Hono()
+declare const message: string
+declare const authorize: (c: Context) => void
+// ---cut---
 app.post('/auth', async (c, next) => {
   try {
     authorize(c)

--- a/docs/api/hono.md
+++ b/docs/api/hono.md
@@ -3,7 +3,7 @@
 `Hono` is the primary object.
 It will be imported first and used until the end.
 
-```ts
+```ts twoslash
 import { Hono } from 'hono'
 
 const app = new Hono()
@@ -35,7 +35,10 @@ The first part of them is used for routing, please refer to the [routing section
 
 `app.notFound` allows you to customize a Not Found Response.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.notFound((c) => {
   return c.text('Custom 404 Message', 404)
 })
@@ -45,7 +48,10 @@ app.notFound((c) => {
 
 `app.onError` handles an error and returns a customized Response.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.onError((err, c) => {
   console.error(`${err}`)
   return c.text('Custom Error Message', 500)
@@ -72,7 +78,12 @@ addEventListener('fetch', (event: FetchEventLike): void => {
 
 For Cloudflare Workers, you can use the following:
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+type Env = any
+type ExecutionContext = any
+// ---cut---
 export default {
   fetch(request: Request, env: Env, ctx: ExecutionContext) {
     return app.fetch(request, env, ctx)
@@ -82,7 +93,10 @@ export default {
 
 or just do:
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 export default app
 ```
 
@@ -104,7 +118,12 @@ export default {  // [!code ++]
 You can pass a URL or pathname to send a GET request.
 `app` will return a `Response` object.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+declare const test: (name: string, fn: () => void) => void
+declare const expect: (value: any) => any
+// ---cut---
 test('GET /hello is ok', async () => {
   const res = await app.request('/hello')
   expect(res.status).toBe(200)
@@ -113,7 +132,12 @@ test('GET /hello is ok', async () => {
 
 You can also pass a `Request` object:
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+declare const test: (name: string, fn: () => void) => void
+declare const expect: (value: any) => any
+// ---cut---
 test('POST /message is ok', async () => {
   const req = new Request('Hello!', {
     method: 'POST',
@@ -155,7 +179,9 @@ Strict mode defaults to `true` and distinguishes the following routes.
 
 By setting strict mode to `false`, both paths will be treated equally.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+// ---cut---
 const app = new Hono({ strict: false })
 ```
 
@@ -163,7 +189,9 @@ const app = new Hono({ strict: false })
 
 The `router` option specifices which router to use. The default router is `SmartRouter`. If you want to use `RegExpRouter`, pass it to a new `Hono` instance:
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+// ---cut---
 import { RegExpRouter } from 'hono/router/reg-exp-router'
 
 const app = new Hono({ router: new RegExpRouter() })
@@ -173,7 +201,11 @@ const app = new Hono({ router: new RegExpRouter() })
 
 You can pass Generics to specify the types of Cloudflare Workers Bindings and variables used in `c.set`/`c.get`.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+type User = any
+declare const user: User
+// ---cut---
 type Bindings = {
   TOKEN: string
 }
@@ -182,7 +214,10 @@ type Variables = {
   user: User
 }
 
-const app = new Hono<{ Bindings: Bindings; Variables: Variables }>()
+const app = new Hono<{
+  Bindings: Bindings
+  Variables: Variables
+}>()
 
 app.use('/auth/*', async (c, next) => {
   const token = c.env.TOKEN // token is `string`

--- a/docs/api/presets.md
+++ b/docs/api/presets.md
@@ -11,7 +11,7 @@ Therefore, you can use them interchangeably.
 
 Usage:
 
-```ts
+```ts twoslash
 import { Hono } from 'hono'
 ```
 
@@ -27,7 +27,7 @@ this.router = new SmartRouter({
 
 Usage:
 
-```ts
+```ts twoslash
 import { Hono } from 'hono/quick'
 ```
 
@@ -43,7 +43,7 @@ this.router = new SmartRouter({
 
 Usage:
 
-```ts
+```ts twoslash
 import { Hono } from 'hono/tiny'
 ```
 

--- a/docs/api/request.md
+++ b/docs/api/request.md
@@ -6,16 +6,21 @@ The `HonoRequest` is an object that can be taken from `c.req` which wraps a [Req
 
 Get the values of path parameters.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 // Captured params
-app.get('/entry/:id', (c) => {
+app.get('/entry/:id', async (c) => {
   const id = c.req.param('id')
-  ...
+  //    ^?
+  // ...
 })
 
 // Get all params at once
-app.get('/entry/:id/comment/:commentId', (c) => {
+app.get('/entry/:id/comment/:commentId', async (c) => {
   const { id, commentId } = c.req.param()
+  //      ^?
 })
 ```
 
@@ -23,17 +28,20 @@ app.get('/entry/:id/comment/:commentId', (c) => {
 
 Get querystring parameters.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 // Query params
-app.get('/search', (c) => {
+app.get('/search', async (c) => {
   const query = c.req.query('q')
-  ...
+  //     ^?
 })
 
 // Get all params at once
-app.get('/search', (c) => {
+app.get('/search', async (c) => {
   const { q, limit, offset } = c.req.query()
-  ...
+  //      ^?
 })
 ```
 
@@ -41,11 +49,15 @@ app.get('/search', (c) => {
 
 Get multiple querystring parameter values, e.g. `/search?tags=A&tags=B`
 
-```ts
-app.get('/search', (c) => {
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
+app.get('/search', async (c) => {
   // tags will be string[]
   const tags = c.req.queries('tags')
-  ...
+  //     ^?
+  // ...
 })
 ```
 
@@ -53,10 +65,14 @@ app.get('/search', (c) => {
 
 Get the request header value.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.get('/', (c) => {
   const userAgent = c.req.header('User-Agent')
-  ...
+  //      ^?
+  return c.text(`Your user agent is ${userAgent}`)
 })
 ```
 
@@ -81,10 +97,13 @@ const foo = c.req.header('X-Foo')
 
 Parse Request body of type `multipart/form-data` or `application/x-www-form-urlencoded`
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.post('/entry', async (c) => {
   const body = await c.req.parseBody()
-  ...
+  // ...
 })
 ```
 
@@ -92,9 +111,13 @@ app.post('/entry', async (c) => {
 
 **Single file**
 
-```ts
+```ts twoslash
+import { Context } from 'hono'
+declare const c: Context
+// ---cut---
 const body = await c.req.parseBody()
-body['foo']
+const data = body['foo']
+//    ^?
 ```
 
 `body['foo']` is `(string | File)`.
@@ -103,7 +126,10 @@ If multiple files are uploaded, the last one will be used.
 
 ### Multiple files
 
-```ts
+```ts twoslash
+import { Context } from 'hono'
+declare const c: Context
+// ---cut---
 const body = await c.req.parseBody()
 body['foo[]']
 ```
@@ -114,7 +140,10 @@ body['foo[]']
 
 ### Multiple files with same name
 
-```ts
+```ts twoslash
+import { Context } from 'hono'
+declare const c: Context
+// ---cut---
 const body = await c.req.parseBody({ all: true })
 body['foo']
 ```
@@ -130,7 +159,7 @@ If you set the `dot` option `true`, the return value is structured based on the 
 
 Imagine receiving the following data:
 
-```ts
+```ts twoslash
 const data = new FormData()
 data.append('obj.key1', 'value1')
 data.append('obj.key2', 'value2')
@@ -138,7 +167,10 @@ data.append('obj.key2', 'value2')
 
 You can get the structured value by setting the `dot` option `true`:
 
-```ts
+```ts twoslash
+import { Context } from 'hono'
+declare const c: Context
+// ---cut---
 const body = await c.req.parseBody({ dot: true })
 // body is `{ obj: { key1: 'value1', key2: 'value2' } }`
 ```
@@ -147,10 +179,13 @@ const body = await c.req.parseBody({ dot: true })
 
 Parses the request body of type `application/json`
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.post('/entry', async (c) => {
   const body = await c.req.json()
-  ...
+  // ...
 })
 ```
 
@@ -158,10 +193,13 @@ app.post('/entry', async (c) => {
 
 Parses the request body of type `text/plain`
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.post('/entry', async (c) => {
   const body = await c.req.text()
-  ...
+  // ...
 })
 ```
 
@@ -169,10 +207,13 @@ app.post('/entry', async (c) => {
 
 Parses the request body as an `ArrayBuffer`
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.post('/entry', async (c) => {
   const body = await c.req.arrayBuffer()
-  ...
+  // ...
 })
 ```
 
@@ -180,10 +221,13 @@ app.post('/entry', async (c) => {
 
 Parses the request body as a `Blob`.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.post('/entry', async (c) => {
   const body = await c.req.blob()
-  ...
+  // ...
 })
 ```
 
@@ -191,10 +235,13 @@ app.post('/entry', async (c) => {
 
 Parses the request body as a `FormData`.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.post('/entry', async (c) => {
   const body = await c.req.formData()
-  ...
+  // ...
 })
 ```
 
@@ -203,9 +250,9 @@ app.post('/entry', async (c) => {
 Get the validated data.
 
 ```ts
-app.post('/posts', (c) => {
+app.post('/posts', async (c) => {
   const { title, body } = c.req.valid('form')
-  ...
+  // ...
 })
 ```
 
@@ -224,7 +271,10 @@ See the [Validation section](/docs/guides/validation) for usage examples.
 
 You can retrieve the registered path within the handler like this:
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.get('/posts/:id', (c) => {
   return c.json({ path: c.req.routePath })
 })
@@ -240,7 +290,10 @@ If you access `/posts/123`, it will return `/posts/:id`:
 
 It returns matched routes within the handler, which is useful for debugging.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.use(async function logger(c, next) {
   await next()
   c.req.matchedRoutes.forEach(({ handler, method, path }, i) => {
@@ -263,10 +316,13 @@ app.use(async function logger(c, next) {
 
 The request pathname.
 
-```ts
-app.get('/about/me', (c) => {
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
+app.get('/about/me', async (c) => {
   const pathname = c.req.path // `/about/me`
-  ...
+  // ...
 })
 ```
 
@@ -274,10 +330,13 @@ app.get('/about/me', (c) => {
 
 The request url strings.
 
-```ts
-app.get('/about/me', (c) => {
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
+app.get('/about/me', async (c) => {
   const url = c.req.url // `http://localhost:8787/about/me`
-  ...
+  // ...
 })
 ```
 
@@ -285,10 +344,13 @@ app.get('/about/me', (c) => {
 
 The method name of the request.
 
-```ts
-app.get('/about/me', (c) => {
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
+app.get('/about/me', async (c) => {
   const method = c.req.method // `GET`
-  ...
+  // ...
 })
 ```
 
@@ -300,6 +362,6 @@ The raw [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) ob
 // For Cloudflare Workers
 app.post('/', async (c) => {
   const metadata = c.req.raw.cf?.hostMetadata?
-  ...
+  // ...
 })
 ```

--- a/docs/api/routing.md
+++ b/docs/api/routing.md
@@ -5,7 +5,10 @@ Let's take a look.
 
 ## Basic
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 // HTTP Methods
 app.get('/', (c) => c.text('GET /'))
 app.post('/', (c) => c.text('POST /'))
@@ -36,49 +39,70 @@ app.on('GET', ['/hello', '/ja/hello', '/en/hello'], (c) =>
 
 ## Path Parameter
 
-```ts
-app.get('/user/:name', (c) => {
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
+app.get('/user/:name', async (c) => {
   const name = c.req.param('name')
-  ...
+  //       ^?
+  // ...
 })
 ```
 
 or all parameters at once:
 
-```ts
-app.get('/posts/:id/comment/:comment_id', (c) => {
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
+app.get('/posts/:id/comment/:comment_id', async (c) => {
   const { id, comment_id } = c.req.param()
-  ...
+  //       ^?
+  // ...
 })
 ```
 
 ## Optional Parameter
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 // Will match `/api/animal` and `/api/animal/:type`
 app.get('/api/animal/:type?', (c) => c.text('Animal!'))
 ```
 
 ## Regexp
 
-```ts
-app.get('/post/:date{[0-9]+}/:title{[a-z]+}', (c) => {
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
+app.get('/post/:date{[0-9]+}/:title{[a-z]+}', async (c) => {
   const { date, title } = c.req.param()
-  ...
+  //       ^?
+  // ...
 })
 ```
 
 ## Including slashes
 
-```ts
-app.get('/posts/:filename{.+\\.png$}', (c) => {
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
+app.get('/posts/:filename{.+\\.png$}', async (c) => {
   //...
 })
 ```
 
 ## Chained route
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app
   .get('/endpoint', (c) => {
     return c.text('GET /endpoint')
@@ -95,7 +119,9 @@ app
 
 You can group the routes with the Hono instance and add them to the main app with the route method.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+// ---cut---
 const book = new Hono()
 
 book.get('/', (c) => c.text('List Books')) // GET /book
@@ -114,7 +140,9 @@ app.route('/book', book)
 
 You can also group multiple instances while keeping base.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+// ---cut---
 const book = new Hono()
 book.get('/book', (c) => c.text('List Books')) // GET /book
 book.post('/book', (c) => c.text('Create Book')) // POST /book
@@ -132,7 +160,9 @@ app.route('/', user) // Handle /user
 
 You can specify the base path.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+// ---cut---
 const api = new Hono().basePath('/api')
 api.get('/book', (c) => c.text('List Books')) // GET /api/book
 ```
@@ -141,7 +171,9 @@ api.get('/book', (c) => c.text('List Books')) // GET /api/book
 
 It works fine if it includes a hostname.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+// ---cut---
 const app = new Hono({
   getPath: (req) => req.url.replace(/^https?:\/([^?]+).*$/, '$1'),
 })
@@ -154,7 +186,9 @@ app.get('/www2.example.com/hello', (c) => c.text('hello www2'))
 
 Hono can handle the `host` header value if you set the `getPath()` function in the Hono constructor.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+// ---cut---
 const app = new Hono({
   getPath: (req) =>
     '/' +
@@ -176,7 +210,10 @@ By applying this, for example, you can change the routing by `User-Agent` header
 
 Handlers or middleware will be executed in registration order.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.get('/book/a', (c) => c.text('a')) // a
 app.get('/book/:slug', (c) => c.text('common')) // common
 ```
@@ -188,7 +225,10 @@ GET /book/b ---> `common`
 
 When a handler is executed, the process will be stopped.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.get('*', (c) => c.text('common')) // common
 app.get('/foo', (c) => c.text('foo')) // foo
 ```
@@ -199,14 +239,21 @@ GET /foo ---> `common` // foo will not be dispatched
 
 If you have the middleware that you want to execute, write the code above the handler.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+import { logger } from 'hono/logger'
+const app = new Hono()
+// ---cut---
 app.use(logger())
 app.get('/foo', (c) => c.text('foo'))
 ```
 
 If you want to have a "_fallback_" handler, write the code below the other handler.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.get('/bar', (c) => c.text('bar')) // bar
 app.get('*', (c) => c.text('fallback')) // fallback
 ```
@@ -236,7 +283,12 @@ GET /two/three/hi ---> `hi`
 
 However, if they are in the wrong order, it will return a 404.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+const two = new Hono()
+const three = new Hono()
+// ---cut---
 three.get('/hi', (c) => c.text('hi'))
 app.route('/two', two) // `two` does not have routes
 two.route('/three', three)

--- a/docs/concepts/benchmarks.md
+++ b/docs/concepts/benchmarks.md
@@ -17,7 +17,12 @@ For example, `find-my-way` is a very fast router used inside Fastify.
 First, we registered the following routing to each of our routers.
 These are similar to those used in the real world.
 
-```ts
+```ts twoslash
+interface Route {
+  method: string
+  path: string
+}
+// ---cut---
 export const routes: Route[] = [
   { method: 'GET', path: '/user' },
   { method: 'GET', path: '/user/comments' },
@@ -36,7 +41,12 @@ export const routes: Route[] = [
 
 Then we sent the Request to the endpoints like below.
 
-```ts
+```ts twoslash
+interface Route {
+  method: string
+  path: string
+}
+// ---cut---
 const routes: (Route & { name: string })[] = [
   {
     name: 'short static',

--- a/docs/concepts/middleware.md
+++ b/docs/concepts/middleware.md
@@ -8,7 +8,10 @@ It's like an onion structure.
 
 For example, we can write the middleware to add the "X-Response-Time" header as follows.
 
-```ts
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+// ---cut---
 app.use(async (c, next) => {
   const start = Date.now()
   await next()

--- a/docs/concepts/stacks.md
+++ b/docs/concepts/stacks.md
@@ -23,7 +23,7 @@ Now let's create an API server and a client with it.
 
 First, write an endpoint that receives a GET request and returns JSON.
 
-```ts
+```ts twoslash
 import { Hono } from 'hono'
 
 const app = new Hono()

--- a/docs/concepts/web-standard.md
+++ b/docs/concepts/web-standard.md
@@ -7,7 +7,7 @@ In addition to `Requests` and `Responses`, there are `URL`, `URLSearchParam`, `H
 Cloudflare Workers, Deno, and Bun also build upon Web Standards.
 For example, a server that returns "Hello World" could be written as below. This could run on Cloudflare Workers and Bun.
 
-```ts
+```ts twoslash
 export default {
   async fetch() {
     return new Response('Hello World')

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ It works on any JavaScript runtime: Cloudflare Workers, Fastly Compute, Deno, Bu
 
 Fast, but not only fast.
 
-```ts
+```ts twoslash
 import { Hono } from 'hono'
 const app = new Hono()
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   "private": true,
   "license": "MIT",
   "devDependencies": {
+    "@shikijs/vitepress-twoslash": "^1.21.0",
+    "hono": "^4.6.3",
     "prettier": "^3.3.2",
     "vitepress": "1.3.4",
     "vitepress-plugin-group-icons": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@shikijs/vitepress-twoslash": "^1.21.0",
     "hono": "^4.6.3",
     "prettier": "^3.3.2",
+    "typescript": "^5.6.2",
     "vitepress": "1.3.4",
     "vitepress-plugin-group-icons": "^1.0.4",
     "vue": "^3.3.4"


### PR DESCRIPTION
I added [Twoslash](https://shiki.matsu.io/packages/vitepress#twoslash) to show TypeScript types.
Documentation users can check type definitions on the website.

![スクリーンショット 2024-10-02 190235](https://github.com/user-attachments/assets/93fb21a9-7685-4282-8139-9c005e475c88)

Docs includes ambiguous codes, it was difficult to write correct TypeScript code. So I couldn't cover all of pages, but I think it has value.