### PR TITLE
fix(jsx): updated useRequestContext example

### DIFF
--- a/docs/middleware/builtin/jsx-renderer.md
+++ b/docs/middleware/builtin/jsx-renderer.md
@@ -159,6 +159,10 @@ app.route('/blog', blog)
 `useRequestContext()` returns an instance of Context.
 
 ```tsx
+import { useRequestContext, jsxRenderer } from 'hono/jsx-renderer'
+
+const app = new Hono().use(jsxRenderer())
+
 const RequestUrlBadge: FC = () => {
   const c = useRequestContext()
   return <b>{c.req.url}</b>
@@ -166,11 +170,9 @@ const RequestUrlBadge: FC = () => {
 
 app.get('/page/info', (c) => {
   return c.render(
-    <RequestContext value={c}>
-      <div>
-        You are accessing: <RequestUrlBadge />
-      </div>
-    </RequestContext>
+    <div>
+      You are accessing: <RequestUrlBadge />
+    </div>
   )
 })
 ```

--- a/docs/middleware/builtin/jsx-renderer.md
+++ b/docs/middleware/builtin/jsx-renderer.md
@@ -161,7 +161,8 @@ app.route('/blog', blog)
 ```tsx
 import { useRequestContext, jsxRenderer } from 'hono/jsx-renderer'
 
-const app = new Hono().use(jsxRenderer())
+const app = new Hono()
+app.use(jsxRenderer())
 
 const RequestUrlBadge: FC = () => {
   const c = useRequestContext()

--- a/docs/middleware/builtin/jsx-renderer.md
+++ b/docs/middleware/builtin/jsx-renderer.md
@@ -166,9 +166,11 @@ const RequestUrlBadge: FC = () => {
 
 app.get('/page/info', (c) => {
   return c.render(
-    <div>
-      You are accessing: <RequestUrlBadge />
-    </div>
+    <RequestContext value={c}>
+      <div>
+        You are accessing: <RequestUrlBadge />
+      </div>
+    </RequestContext>
   )
 })
 ```


### PR DESCRIPTION
Closes #513 

- Added the `RequestContext` provider to make the example more easy to understand by everyone.