### PR TITLE
Update best-practices.md

### DIFF
--- a/docs/guides/best-practices.md
+++ b/docs/guides/best-practices.md
@@ -110,3 +110,21 @@ app.route('/books', books)
 
 export default app
 ```
+The above code would work fine, however doing this would lose the typesafe
+
+a better solution would be something like this
+
+```ts
+// authors.ts
+import { Hono } from "hono";
+
+const app = new Hono()
+  .get("/", (c) => c.json("list authors"))
+  .post("/", (c) => c.json("create an author", 201))
+  .get("/:id", (c) => c.json(`get ${c.req.param("id")}`));
+
+export default app;
+```
+
+this way when you use this route, the types can be properly infered 
+


### PR DESCRIPTION
I tested this out, when building in a monorepo setup and noticed that when you don't chain one method after another you lose the typesafety you get when using `hc<appType>`