### PR TITLE
docs(guide-basic): clarity on `Return HTML`

### DIFF
--- a/docs/getting-started/basic.md
+++ b/docs/getting-started/basic.md
@@ -174,7 +174,7 @@ app.delete('/posts/:id', (c) =>
 
 ## Return HTML
 
-Hono is also suitable for returning a little HTML. Rename the file to `src/index.tsx` and configure it to use JSX (check with each runtime as it is different). You don't need to use a huge front-end framework.
+You can write HTML with [the html Helper](/docs/helpers/html) or using [JSX](/docs/guides/jsx) syntax. If you want to use JSX, rename the file to `src/index.tsx` and configure it (check with each runtime as it is different). Below is an example using JSX.
 
 ```tsx
 const View = () => {


### PR DESCRIPTION
Fixes #519

* Removed ambiguous and unnecessary parts.
* Added "html Helper".