### PR TITLE
docs(getting-started/vercel): add Node.js runtime usage for App Router

### DIFF
--- a/docs/getting-started/vercel.md
+++ b/docs/getting-started/vercel.md
@@ -141,13 +141,37 @@ If you have a Vercel account, you can deploy by linking the Git repository.
 
 You can also run Hono on Next.js running on the Node.js runtime.
 
-First, install the Node.js adapter.
+### App Router
+
+For the App Router, you can simply set the runtime to `nodejs` in your route handler:
+
+```ts
+import { Hono } from 'hono'
+import { handle } from 'hono/vercel'
+
+export const runtime = 'nodejs'
+
+const app = new Hono().basePath('/api')
+
+app.get('/hello', (c) => {
+  return c.json({
+    message: 'Hello from Hono!',
+  })
+})
+
+export const GET = handle(app)
+export const POST = handle(app)
+```
+
+### Page Router
+
+For the Page Router, you'll need to install the Node.js adapter first:
 
 ```sh
 npm i @hono/node-server
 ```
 
-Next, you can utilize the `handle` function imported from `@hono/node-server/vercel`.
+Then, you can utilize the `handle` function imported from `@hono/node-server/vercel`:
 
 ```ts
 import { Hono } from 'hono'
@@ -171,6 +195,6 @@ app.get('/hello', (c) => {
 export default handle(app)
 ```
 
-In order for this to work, it's important to disable Vercel node.js helpers by setting up an enviroment variable in your project dashboard or in your `.env` file
+In order for this to work with the Page Router, it's important to disable Vercel node.js helpers by setting up an environment variable in your project dashboard or in your `.env` file:
 
 `NODEJS_HELPERS=0`

--- a/docs/getting-started/vercel.md
+++ b/docs/getting-started/vercel.md
@@ -167,9 +167,25 @@ export const POST = handle(app)
 
 For the Page Router, you'll need to install the Node.js adapter first:
 
-```sh
+::: code-group
+
+```sh [npm]
 npm i @hono/node-server
 ```
+
+```sh [yarn]
+yarn add @hono/node-server
+```
+
+```sh [pnpm]
+pnpm add @hono/node-server
+```
+
+```sh [bun]
+bun add @hono/node-server
+```
+
+:::
 
 Then, you can utilize the `handle` function imported from `@hono/node-server/vercel`:
 
@@ -197,4 +213,6 @@ export default handle(app)
 
 In order for this to work with the Page Router, it's important to disable Vercel node.js helpers by setting up an environment variable in your project dashboard or in your `.env` file:
 
-`NODEJS_HELPERS=0`
+```text
+NODEJS_HELPERS=0
+```


### PR DESCRIPTION
This PR adds documentation for using Hono with Next.js Node.js runtime in App Router setup.

Changes:
- Add new section showing how to use Node.js runtime with App Router
- Reorganize the Node.js section to clearly separate App Router and Page Router implementations
- Document that App Router doesn't require @hono/node-server package
- Maintain existing Page Router implementation details

The App Router implementation is simpler as it only requires setting `runtime = 'nodejs'` without additional packages.

Closes #529 