### PR TITLE
fix: bluesky icon is not showing up

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "hono": "^4.6.3",
     "prettier": "^3.3.2",
     "typescript": "^5.6.2",
-    "vitepress": "1.3.4",
+    "vitepress": "1.5.0",
     "vitepress-plugin-group-icons": "^1.0.4",
     "vue": "^3.3.4"
   }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4a2955c2-958d-47ad-9f20-dbbac80d349c)

This updates `vitepress` version to enable the blue sky logo to display correctly. Apologies for missing this file in PR #533—it has now been included.