### PR TITLE
docs(middleware): add better-auth to authentication list

### DIFF
--- a/docs/middleware/third-party.md
+++ b/docs/middleware/third-party.md
@@ -11,6 +11,7 @@ Most of this middleware leverages external libraries.
 - [OIDC Auth](https://github.com/honojs/middleware/tree/main/packages/oidc-auth)
 - [Firebase Auth](https://github.com/honojs/middleware/tree/main/packages/firebase-auth)
 - [Verify RSA JWT (JWKS)](https://github.com/wataruoguchi/verify-rsa-jwt-cloudflare-worker)
+- [Better Auth](https://www.better-auth.com/docs/integrations/hono)
 
 ### Validators
 


### PR DESCRIPTION
Adding [BetterAuth](https://www.better-auth.com/) to the third-party middleware section to documentation.