### PR TITLE
docs: project creation with `deno init`

### DIFF
--- a/docs/getting-started/basic.md
+++ b/docs/getting-started/basic.md
@@ -25,7 +25,7 @@ bun create hono@latest my-app
 ```
 
 ```sh [deno]
-deno run -A npm:create-hono@latest my-app
+deno init --npm hono@latest my-app
 ```
 
 :::

--- a/docs/getting-started/cloudflare-pages.md
+++ b/docs/getting-started/cloudflare-pages.md
@@ -31,7 +31,7 @@ bunx create-hono my-app
 ```
 
 ```sh [deno]
-deno run -A npm:create-hono my-app
+deno init --npm hono my-app
 ```
 
 :::

--- a/docs/getting-started/cloudflare-workers.md
+++ b/docs/getting-started/cloudflare-workers.md
@@ -32,7 +32,7 @@ bunx create-hono my-app
 ```
 
 ```sh [deno]
-deno run -A npm:create-hono my-app
+deno init --npm hono my-app
 ```
 
 :::

--- a/docs/getting-started/deno.md
+++ b/docs/getting-started/deno.md
@@ -16,7 +16,7 @@ A starter for Deno is available.
 Start your project with "create-hono" command.
 
 ```sh
-deno run -A npm:create-hono my-app
+deno init --npm hono my-app
 ```
 
 Select `deno` template for this example.

--- a/docs/getting-started/fastly.md
+++ b/docs/getting-started/fastly.md
@@ -44,7 +44,7 @@ bunx create-hono my-app
 ```
 
 ```sh [deno]
-deno run -A npm:create-hono my-app
+deno init --npm hono my-app
 ```
 
 :::

--- a/docs/getting-started/netlify.md
+++ b/docs/getting-started/netlify.md
@@ -29,7 +29,7 @@ bunx create-hono my-app
 ```
 
 ```sh [deno]
-deno run -A npm:create-hono my-app
+deno init --npm hono my-app
 ```
 
 :::

--- a/docs/getting-started/nodejs.md
+++ b/docs/getting-started/nodejs.md
@@ -39,7 +39,7 @@ bunx create-hono my-app
 ```
 
 ```sh [deno]
-deno run -A npm:create-hono my-app
+deno init --npm hono my-app
 ```
 
 :::

--- a/docs/getting-started/vercel.md
+++ b/docs/getting-started/vercel.md
@@ -32,7 +32,7 @@ bunx create-hono my-app
 ```
 
 ```sh [deno]
-deno run -A npm:create-hono my-app
+deno init --npm hono my-app
 ```
 
 :::

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ bun create hono@latest
 ```
 
 ```sh [deno]
-deno run -A npm:create-hono@latest
+deno init --npm hono@latest
 ```
 
 :::


### PR DESCRIPTION
A simplified command has appeared, so use that.
`deno run -A npm:create-hono` => `deno init --npm hono`
https://deno.com/blog/v2.1#deno-init---npm-vite