### PR TITLE
docs: add hono simple di

### DIFF
--- a/docs/middleware/third-party.md
+++ b/docs/middleware/third-party.md
@@ -44,3 +44,4 @@ Most of this middleware leverages external libraries.
 - [Sentry](https://github.com/honojs/middleware/tree/main/packages/sentry)
 - [tRPC Server](https://github.com/honojs/middleware/tree/main/packages/trpc-server)
 - [Geo](https://github.com/ktkongtong/hono-geo-middleware/tree/main/packages/middleware)
+- [Hono Simple DI](https://github.com/maou-shonen/hono-simple-DI)


### PR DESCRIPTION
this middleware wraps hono's context api in a neat little package for dependency injection. I think this is a really good addition to the list of the linked 3rd party middlewares. I also discussed the addition with the author (see: https://github.com/maou-shonen/hono-simple-DI/issues/15).