### PR TITLE
Add Highlight.io to third-party integrations

### DIFF
--- a/docs/middleware/third-party.md
+++ b/docs/middleware/third-party.md
@@ -45,3 +45,4 @@ Most of this middleware leverages external libraries.
 - [tRPC Server](https://github.com/honojs/middleware/tree/main/packages/trpc-server)
 - [Geo](https://github.com/ktkongtong/hono-geo-middleware/tree/main/packages/middleware)
 - [Hono Simple DI](https://github.com/maou-shonen/hono-simple-DI)
+- [Highlight.io](https://www.highlight.io/docs/getting-started/backend-sdk/js/hono)


### PR DESCRIPTION
Highlighit.io recently built a custom Hono middleware that can be used to quickly configure Highlight to collect logs and traces from a Hono app. This PR adds a link to learn about it under the third-party middleware docs.