### PR TITLE
Fix linter warning (Deno)

### DIFF
--- a/docs/getting-started/basic.md
+++ b/docs/getting-started/basic.md
@@ -197,7 +197,7 @@ app.get('/page', (c) => {
 You can also return the raw [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response).
 
 ```ts
-app.get('/', (c) => {
+app.get('/', () => {
   return new Response('Good morning!')
 })
 ```


### PR DESCRIPTION
Deno linter problem: 'c' is declared but its value is never read.

We fix this by not destructuring the context parameter. We could have instead prefixed it with an underscore, but since the purpose of this document is to remain simple and easy to consume, we preferred this approach. There might be some good reasons why this document would want to retain the context param, so feel free to close this if that's the case!