### PR TITLE
Remove boundary assertion from regex example

### DIFF
--- a/docs/api/routing.md
+++ b/docs/api/routing.md
@@ -92,7 +92,7 @@ app.get('/post/:date{[0-9]+}/:title{[a-z]+}', async (c) => {
 import { Hono } from 'hono'
 const app = new Hono()
 // ---cut---
-app.get('/posts/:filename{.+\\.png$}', async (c) => {
+app.get('/posts/:filename{.+\\.png}', async (c) => {
   //...
 })
 ```


### PR DESCRIPTION
From what I understand, param regexes are always anchored. As such the second example is misleading as it implies the opposite.