### PR TITLE
docs(middleware): Add event emitter to third party middleware section

### DIFF
--- a/docs/middleware/third-party.md
+++ b/docs/middleware/third-party.md
@@ -33,6 +33,7 @@ Most of this middleware leverages external libraries.
 
 - [Bun Transpiler](https://github.com/honojs/middleware/tree/main/packages/bun-transpiler)
 - [esbuild Transpiler](https://github.com/honojs/middleware/tree/main/packages/esbuild-transpiler)
+- [Event Emitter](https://github.com/honojs/middleware/tree/main/packages/event-emitter)
 - [GraphQL Server](https://github.com/honojs/middleware/tree/main/packages/graphql-server)
 - [Hono Rate Limiter](https://github.com/rhinobase/hono-rate-limiter)
 - [Node WebSocket Helper](https://github.com/honojs/middleware/tree/main/packages/node-ws)


### PR DESCRIPTION
Added the event emitter middleware (https://github.com/honojs/middleware/tree/main/packages/event-emitter) to the third-party middleware list.