### PR TITLE
docs(middleware/third-party): added a link to Pino logging middleware for Hono

### DIFF
--- a/docs/middleware/third-party.md
+++ b/docs/middleware/third-party.md
@@ -47,3 +47,4 @@ Most of this middleware leverages external libraries.
 - [Geo](https://github.com/ktkongtong/hono-geo-middleware/tree/main/packages/middleware)
 - [Hono Simple DI](https://github.com/maou-shonen/hono-simple-DI)
 - [Highlight.io](https://www.highlight.io/docs/getting-started/backend-sdk/js/hono)
+- [Pino logger](https://github.com/maou-shonen/hono-pino)


### PR DESCRIPTION
Pino is a more configurable alternative to the built-in logger.