### PR TITLE
Fix deno add command

### DIFF
--- a/docs/getting-started/deno.md
+++ b/docs/getting-started/deno.md
@@ -179,7 +179,7 @@ Testing the application on Deno is easy.
 You can write with `Deno.test` and use `assert` or `assertEquals` from [@std/assert](https://jsr.io/@std/assert).
 
 ```sh
-deno add @std/assert
+deno add jsr:@std/assert
 ```
 
 ```ts


### PR DESCRIPTION
The jsr: prefix is needed, otherwise the previous command fails with Deno 2.

Screenshot showing the error and then fix:

<img width="609" alt="image" src="https://github.com/user-attachments/assets/a16fa3e1-c2ad-4a4c-b7eb-e9a41881da98" />
