### PR TITLE
docs(middleware/compress): Add a compress middleware option

### DIFF
--- a/docs/middleware/builtin/compress.md
+++ b/docs/middleware/builtin/compress.md
@@ -28,3 +28,7 @@ app.use(compress())
 ### <Badge type="info" text="optional" /> encoding: `'gzip'` | `'deflate'`
 
 The compression scheme to allow for response compression. Either `gzip` or `deflate`. If not defined, both are allowed and will be used based on the `Accept-Encoding` header. `gzip` is prioritized if this option is not provided and the client provides both in the `Accept-Encoding` header.
+
+### <Badge type="info" text="optional" /> threshold: `number`
+
+The minimum size in bytes to compress. Defaults to 1024 bytes.


### PR DESCRIPTION
Add `options.threshold` to the documentation as it is already implemented.