### PR TITLE
docs(factory): remove experimental from createApp

### DIFF
--- a/docs/helpers/factory.md
+++ b/docs/helpers/factory.md
@@ -80,7 +80,7 @@ const handlers = factory.createHandlers(logger(), middleware, (c) => {
 app.get('/api', ...handlers)
 ```
 
-## `factory.createApp()` <Badge style="vertical-align: middle;" type="warning" text="Experimental" />
+## `factory.createApp()`
 
 `createApp()` helps to create an instance of Hono with the proper types. If you use this method with `createFactory()`, you can avoid redundancy in the definition of the `Env` type.
 


### PR DESCRIPTION
The `@experimental` of createApp has already been removed, so I remove experimental from the document.

https://github.com/honojs/hono/pull/3164