### PR TITLE
Clarify allowed token format to avoid surprises

### DIFF
--- a/docs/middleware/builtin/bearer-auth.md
+++ b/docs/middleware/builtin/bearer-auth.md
@@ -18,7 +18,8 @@ import { bearerAuth } from 'hono/bearer-auth'
 
 ## Usage
 
-NOTE: Your `token` must match the regex `/[A-Za-z0-9._~+/-]+=*/`, otherwise a 400 error will be returned. Notably, this regex acommodates both URL-safe Base64- and standard Base64-encoded JWTs. This middleware does not require the bearer token to be a JWT, just that it matches the above regex.
+> [!NOTE]
+> Your `token` must match the regex `/[A-Za-z0-9._~+/-]+=*/`, otherwise a 400 error will be returned. Notably, this regex acommodates both URL-safe Base64- and standard Base64-encoded JWTs. This middleware does not require the bearer token to be a JWT, just that it matches the above regex.
 
 ```ts
 const app = new Hono()

--- a/docs/middleware/builtin/bearer-auth.md
+++ b/docs/middleware/builtin/bearer-auth.md
@@ -18,6 +18,8 @@ import { bearerAuth } from 'hono/bearer-auth'
 
 ## Usage
 
+NOTE: Your `token` must match the regex `/[A-Za-z0-9._~+/-]+=*/`, otherwise a 400 error will be returned. Notably, this regex acommodates both URL-safe Base64- and standard Base64-encoded JWTs. This middleware does not require the bearer token to be a JWT, just that it matches the above regex.
+
 ```ts
 const app = new Hono()
 


### PR DESCRIPTION
This PR adds some helpful documentation alerting users to the fact that tokens cannot contain arbitrary characters. They must match the regex `TOKEN_STRINGS` defined in the hono codebase, otherwise a 400 error is returned indicating an invalid request.
