### PR TITLE
Fix typo and improve sentence clarity in documentation

### DIFF
--- a/examples/prisma.md
+++ b/examples/prisma.md
@@ -285,4 +285,4 @@ export default app
 
 :::
 
-This will return all users in route `/` using Postman or Client Thunder to see the result.
+This will return all users in the `/` route, using Postman or Thunder Client to see the result.


### PR DESCRIPTION
This PR fixes a typo in the documentation, correcting "Client Thunder" to "Thunder Client" which is the correct extension name. Also added some punctuation to improve sentence readability.

The previous sentence was:

> This will return all users in route `/`  using Postman or Client Thunder  to see the result.

The updated sentence is:

> This will return all users in the `/` route, using Postman or Thunder Client to see the result.
