### PR TITLE
chore(middleware): fix Scalar API Refrence 404 not found

### DIFF
--- a/docs/middleware/third-party.md
+++ b/docs/middleware/third-party.md
@@ -25,7 +25,7 @@ Most of this middleware leverages external libraries.
 ### OpenAPI
 
 - [Zod OpenAPI](https://github.com/honojs/middleware/tree/main/packages/zod-openapi)
-- [Scalar API Reference](https://github.com/scalar/scalar/tree/main/packages/hono-api-reference)
+- [Scalar API Reference](https://github.com/scalar/scalar/tree/main/integrations/hono)
 - [Swagger UI](https://github.com/honojs/middleware/tree/main/packages/swagger-ui)
 - [Hono OpenAPI](https://github.com/rhinobase/hono-openapi)
 


### PR DESCRIPTION
I fixed tirhd party page Scalar API Refrence link broken.

**Target page**
https://hono.dev/docs/middleware/third-party

This link is broken.
https://github.com/scalar/scalar/tree/main/packages/hono-api-reference