### PR TITLE
Patching types of c.env

### DIFF
--- a/docs/helpers/adapter.md
+++ b/docs/helpers/adapter.md
@@ -15,11 +15,11 @@ The `env()` function facilitates retrieving environment variables across differe
 
 ```ts
 import { env } from 'hono/adapter'
-
+const app = new Hono<{Bindings:{ NAME: string }}>()
 app.get('/env', (c) => {
   // NAME is process.env.NAME on Node.js or Bun
   // NAME is the value written in `wrangler.toml` on Cloudflare
-  const { NAME } = env<{ NAME: string }>(c)
+  const { NAME } = env(c)
   return c.text(NAME)
 })
 ```


### PR DESCRIPTION
Problem: TS2345: Argument of type Context<BlankEnv, "/ env", BlankInput> is not assignable to parameter of types

Patch: Directly applying binding types to the hono constructor fixes the types issue, i found out this in the cloudfare section of loading env