### PR TITLE
docs(concepts): fix tanstack/react-query example

### DIFF
--- a/docs/concepts/stacks.md
+++ b/docs/concepts/stacks.md
@@ -201,22 +201,20 @@ const Todos = () => {
     InferResponseType<typeof $post>,
     Error,
     InferRequestType<typeof $post>['form']
-  >(
-    async (todo) => {
+  >({
+    mutationFn: async (todo) => {
       const res = await $post({
         form: todo,
       })
       return await res.json()
     },
-    {
-      onSuccess: async () => {
-        queryClient.invalidateQueries({ queryKey: ['todos'] })
-      },
-      onError: (error) => {
-        console.log(error)
-      },
-    }
-  )
+    onSuccess: async () => {
+      queryClient.invalidateQueries({ queryKey: ['todos'] })
+    },
+    onError: (error) => {
+      console.log(error)
+    },
+  })
 
   return (
     <div>


### PR DESCRIPTION
Fixed compatibility with the latest version of the tanstack/react-query package.

https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-v5
https://tanstack.com/query/latest/docs/framework/react/reference/useMutation