### PR TITLE
Normalize links (removing .md extension)

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -19,7 +19,7 @@ const sidebars = (): DefaultTheme.SidebarItem[] => [
       { text: 'Middleware', link: '/docs/concepts/middleware' },
       {
         text: 'Developer Experience',
-        link: '/docs/concepts/developer-experience.md',
+        link: '/docs/concepts/developer-experience',
       },
       { text: 'Hono Stacks', link: '/docs/concepts/stacks' },
     ],


### PR DESCRIPTION
Set the same `link` setting as the others.
It could be the cause of some kind of error?
Example:
![image](https://github.com/user-attachments/assets/03263be5-fc10-4e7d-ae25-aa6e41fc8a3a)

