### PR TITLE
for llm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ $RECYCLE.BIN/
 
 # IDE-specific settings
 .idea
+
+# summary
+public/hono-docs.md

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "dev": "vitepress dev",
-    "build": "vitepress build",
+    "combine-docs": "node scripts/combineDocs.js",
+    "build": "vitepress build && npm run combine-docs",
     "preview": "vitepress preview",
     "format": "yarn prettier --check ./docs ./examples index.md",
     "format:fix": "yarn prettier --check --write ./docs ./examples index.md"

--- a/scripts/combineDocs.js
+++ b/scripts/combineDocs.js
@@ -1,0 +1,66 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Collects all Markdown files within the specified directory recursively,
+ * sorts them by relative path, and merges them.
+ * The output file will only be rewritten if its content changes.
+ *
+ * @param {string} dir        The source directory path for merging
+ * @param {string} outputFile The path of the output file
+ */
+function combineMarkdownFiles(dir, outputFile) {
+  const markdownFiles = [];
+  const excludedFiles = ['hono-docs.md']; // Files to be excluded
+
+  // Function to recursively collect Markdown file paths
+  function walkSync(currentDir) {
+    const dirents = fs.readdirSync(currentDir, { withFileTypes: true });
+    for (const dirent of dirents) {
+      const filePath = path.join(currentDir, dirent.name);
+
+      // Check for excluded files
+      if (excludedFiles.includes(path.basename(filePath))) {
+        continue; // Skip to the next file
+      }
+
+      if (dirent.isDirectory()) {
+        walkSync(filePath);
+      } else if (dirent.isFile() && path.extname(dirent.name) === '.md') {
+        markdownFiles.push(filePath);
+      }
+    }
+  }
+
+  walkSync(dir);
+
+  // Sort the collected file paths by their relative paths from the root directory.
+  // This ensures a consistent order each time the function is executed.
+  markdownFiles.sort((a, b) => {
+    const relativeA = path.relative(dir, a);
+    const relativeB = path.relative(dir, b);
+    return relativeA.localeCompare(relativeB);
+  });
+
+  // Read the content of each Markdown file and join them with two newline characters as a separator
+  const combinedContent = markdownFiles
+    .map(file => fs.readFileSync(file, 'utf8'))
+    .join('\n\n');
+
+  // Compare the content of the existing output file, and only rewrite it if there are changes
+  let previousContent = '';
+  if (fs.existsSync(outputFile)) {
+    previousContent = fs.readFileSync(outputFile, 'utf8');
+  }
+  if (previousContent !== combinedContent) {
+    fs.writeFileSync(outputFile, combinedContent);
+    console.log(`Output updated: ${outputFile}`);
+  } else {
+    console.log('No changes detected. Output file remains unchanged.');
+  }
+}
+
+combineMarkdownFiles(
+  path.join(import.meta.dirname, '../docs'),
+  path.join(import.meta.dirname, '../public/hono-docs.md')
+);


### PR DESCRIPTION
This is a solution to compile the latest specifications of Hono into a single Markdown document for better understanding by LLMs. By using this, you can help ChatGPT or Claude comprehend the content of the Hono documentation.

e.g.

- https://duckdb.org/duckdb-docs.md
