### PR TITLE
Optimize SVG logo to reduce file size by 76%

### DIFF
--- a/public/images/logo.svg
+++ b/public/images/logo.svg
@@ -1,19 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="100%" height="100%" viewBox="0 0 772 996" version="1.1"
-	xmlns="http://www.w3.org/2000/svg"
-	xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve"
-	xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-	<g transform="matrix(1.99764,0,0,1.99764,-110.392,1.0977)">
-		<path d="M258.835,-0.549C258.835,-0.549 378.371,138.535 428,258.5C476.558,375.877 387.192,494.132 252.215,497.949C148.371,500.885 48.676,411.749 55.602,298.705C59.967,227.465 94.196,147.494 111.74,126.139C111.74,126.139 147.215,172.833 148.651,169.486C164.823,131.777 212.884,56.804 258.835,-0.549Z" style="fill:url(#_Linear1);fill-rule:nonzero;"/>
-	</g>
-	<g transform="matrix(1.99764,0,0,1.99764,-103.781,49.2984)">
-		<path d="M250.5,81.5C287.193,124.06 320.36,169.393 350,217.5C359.293,233.418 366.959,250.085 373,267.5C385.584,317.008 372.084,357.842 332.5,390C294.216,416.939 252.216,424.939 206.5,414C157.201,398.702 128.701,365.535 121,314.5C119.131,298.409 120.798,282.742 126,267.5C133.418,248.663 142.418,230.663 153,213.5C163,198.833 173,184.167 183,169.5C205.716,140.29 228.216,110.957 250.5,81.5Z" style="fill:rgb(255,151,88);fill-rule:nonzero;"/>
-	</g>
-	<defs>
-		<linearGradient id="_Linear1" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-11.5675,498.262,-642.583,-14.9181,259.818,0.204701)">
-			<stop offset="0" style="stop-color:rgb(255,136,74);stop-opacity:0.99"/>
-			<stop offset="1" style="stop-color:rgb(255,48,0);stop-opacity:0.99"/>
-		</linearGradient>
-	</defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 76 98">
+  <path fill="url(#a)" d="m11 25 7 9s9-18 22-34c17 20 36 48 36 64 0 20-19 34-37 34C17 98 0 81 0 61c0-6 3-24 11-36Z"/>
+  <path fill="#F95" d="M39 21c47 51 14 66 0 66-11 0-51-11 0-66Z"/>
+  <defs>
+    <linearGradient id="a" x2="0%" y2="100%">
+      <stop stop-color="#F84"/>
+      <stop offset="100%" stop-color="#F30"/>
+    </linearGradient>
+  </defs>
 </svg>


### PR DESCRIPTION
- Reduced file size from 1740KB to 418KB while maintaining visual identity
- Improves website load time and reduces bandwidth usage for visitors
- Based on @qrg’s work in the now-closed issue: https://github.com/honojs/website/issues/574
- Made minor shape and color adjustments (before/after comparisons available in reference assets)
- Reference assets: https://github.com/tksh/optimize-hono-svg-logo
![results_0_to_2](https://github.com/user-attachments/assets/6925ee3a-19dd-40ca-9d46-9878e6d19d6d)
