### PR TITLE
docs: add some details to address common questions

### DIFF
--- a/docs/concepts/stacks.md
+++ b/docs/concepts/stacks.md
@@ -66,6 +66,12 @@ app.get(
 
 To emit an endpoint specification, export its type.
 
+::: warning
+
+For the RPC to infer routes correctly, all inlcuded methods must be chained, and the endpoint or app type must be inferred from a declared variable. For more, see [Best Practices for RPC](https://hono.dev/docs/guides/best-practices#if-you-want-to-use-rpc-features).
+
+:::
+
 ```ts{1,17}
 const route = app.get(
   '/hello',

--- a/docs/getting-started/nodejs.md
+++ b/docs/getting-started/nodejs.md
@@ -217,9 +217,20 @@ const server = serve({
 })
 ```
 
-## Dockerfile
+## Building & Deployment
 
-Here is an example of a Dockerfile.
+Complete the following steps to build a simple Hono app. Apps with a front-end framework may need to use [Hono's Vite plugins](https://github.com/honojs/vite-plugins).
+
+1. Add `"outDir": "./dist"` to the `compilerOptions` section `tsconfig.json`.
+2. Add `"exclude": ["node_modules"]` to `tsconfig.json`.
+3. Add `"build": "tsc"` to `script` section of `package.json`.
+4. Run `npm install typescript --save-dev`.
+5. Add `"type": "module"` to `package.json`.
+6. Run `npm run build`!
+
+### Dockerfile
+
+Here is an example of a Dockerfile. You must complete steps 1-5 above before this build and deployment process will work.
 
 ```Dockerfile
 FROM node:20-alpine AS base
@@ -250,11 +261,3 @@ EXPOSE 3000
 
 CMD ["node", "/app/dist/index.js"]
 ```
-
-The following steps shall be taken in advance.
-
-1. Add `"outDir": "./dist"` to the `compilerOptions` section `tsconfig.json`.
-2. Add `"exclude": ["node_modules"]` to `tsconfig.json`.
-3. Add `"build": "tsc"` to `script` section of `package.json`.
-4. Run `npm install typescript --save-dev`.
-5. Add `"type": "module"` to `package.json`.

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -142,7 +142,7 @@ However, embedding middleware directly within `app.use()` can limit its reusabil
 middleware into different files.
 
 To ensure we don't lose type definitions for `context` and `next`, when separating middleware, we can use
-[`createMiddleware()`](/docs/helpers/factory#createmiddleware) from Hono's factory.
+[`createMiddleware()`](/docs/helpers/factory#createmiddleware) from Hono's factory. This also allows us to type-safely [access data we've `set` in `Context`](https://hono.dev/docs/api/context#set-get) from downstream handlers.
 
 ```ts
 import { createMiddleware } from 'hono/factory'

--- a/docs/guides/rpc.md
+++ b/docs/guides/rpc.md
@@ -2,7 +2,7 @@
 
 The RPC feature allows sharing of the API specifications between the server and the client.
 
-You can export the types of input type specified by the Validator and the output type emitted by `json()` when called in a handler. And Hono Client will be able to import it. At this time, responses returned from middleware are [not inferred by the client.](https://github.com/honojs/hono/issues/2719)
+Using the `AppType` exported from your server code, the Hono Client can infer both the input type(s) specified by the Validator, and the output type(s) emitted by handlers returning `c.json()`. At this time, responses returned from middleware are [not inferred by the client.](https://github.com/honojs/hono/issues/2719)
 
 > [!NOTE]  
 > For the RPC types to work properly in a monorepo, in both the Client's and Server's tsconfig.json files, set `"strict": true` in `compilerOptions`. [Read more.](https://github.com/honojs/hono/issues/2270#issuecomment-2143745118)

--- a/docs/guides/rpc.md
+++ b/docs/guides/rpc.md
@@ -1,8 +1,13 @@
 # RPC
 
-The RPC feature allows sharing of the API specifications between the server and the client.
+The RPC feature allows sharing of the API specifications between the server and the client. 
 
-Using the `AppType` exported from your server code, the Hono Client can infer both the input type(s) specified by the Validator, and the output type(s) emitted by handlers returning `c.json()`. At this time, responses returned from middleware are [not inferred by the client.](https://github.com/honojs/hono/issues/2719)
+First, export the `typeof` your Hono app (commonly called `AppType`)—or just the routes you want available to the client—from your server code.
+
+By accepting `AppType` as a generic parameter, the Hono Client can infer both the input type(s) specified by the Validator, and the output type(s) emitted by handlers returning `c.json()`. 
+
+> [!NOTE]
+> At this time, responses returned from middleware are [not inferred by the client.](https://github.com/honojs/hono/issues/2719)
 
 > [!NOTE]  
 > For the RPC types to work properly in a monorepo, in both the Client's and Server's tsconfig.json files, set `"strict": true` in `compilerOptions`. [Read more.](https://github.com/honojs/hono/issues/2270#issuecomment-2143745118)

--- a/docs/guides/rpc.md
+++ b/docs/guides/rpc.md
@@ -2,7 +2,7 @@
 
 The RPC feature allows sharing of the API specifications between the server and the client.
 
-You can export the types of input type specified by the Validator and the output type emitted by `json()`. And Hono Client will be able to import it.
+You can export the types of input type specified by the Validator and the output type emitted by `json()` when called in a handler. And Hono Client will be able to import it. At this time, responses returned from middleware are [not inferred by the client.](https://github.com/honojs/hono/issues/2719)
 
 > [!NOTE]  
 > For the RPC types to work properly in a monorepo, in both the Client's and Server's tsconfig.json files, set `"strict": true` in `compilerOptions`. [Read more.](https://github.com/honojs/hono/issues/2270#issuecomment-2143745118)


### PR DESCRIPTION
## TL;DR
Made a few additions based on questions I've seen come up frequently on Discord. More can probably be done, but I wanted to keep changes contained. Let me know if I should have created an issue or something instead.

### Stacks
Added some details about RPC inference and chaining. In my opinion, the examples are a little confusing because they use `const route` for the RPC typing (which isn't really explained). I actually missed that the first time I read through, and initially thought the examples were actually breaking.
- https://discord.com/channels/1011308539819597844/1346424853196050472/1346438748342190141

  ```typescript
  const app = new Hono()
  // directly chaining here, and using `typeof app`,  
  // seems more consistent w other Hono docs, and
  // how many devs architect apps
  const route = app.get(/** */)
  // this name is also a little misleading
  export AppType = typeof route
  ```
### Getting Started: NodeJS
Moved build-prep steps before dockerfile example, and added a bit about Vite. I haven't seen much about the Vite plugins in the docs, or even links to the repo (except for ssg).
- https://discord.com/channels/1011308539819597844/1012485912409690122/1345994752197267539

### Middleware
Added a little info about getting middleware types in handlers. This seems to be a common source of confusion or misunderstanding, especially when it comes to how chaining vs injecting middleware affects typing.

### RPC
Specified that RPC cannot currently infer types from middleware, and linked the issue.