### PR TITLE
docs: document `addValidatedData` method

### DIFF
--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -30,12 +30,13 @@ app.post(
       body: body,
     }
   }),
-  //...
+  // ...
 ```
 
 Within the handler you can get the validated value with `c.req.valid('form')`.
 
 ```ts
+// after your middleware...
 , (c) => {
   const { body } = c.req.valid('form')
   // ... do something
@@ -162,12 +163,11 @@ app.post(
   }
 ```
 
-## With Zod
+## Validator with Zod
 
-You can use [Zod](https://zod.dev), one of third-party validators.
-We recommend using a third-party validator.
+You can use [Zod](https://zod.dev), or the (typed) validator you prefer, to simplify `validator` callback logic. In essence, this is what our [third-party validators](#with-a-third-party-validator) are doing internally.
 
-Install from the Npm registry.
+Install from the NPM registry.
 
 ::: code-group
 
@@ -228,9 +228,17 @@ const route = app.post(
 )
 ```
 
-## Zod Validator Middleware
+## Third-party validator middleware
+We recommend using one of our [supported third-party validators,](https://hono.dev/docs/middleware/third-party#validators) which internally call `hono/validator`. These libraries make for both a better developer and user experience by simplifying (typed) validation.
 
-You can use the [Zod Validator Middleware](https://github.com/honojs/middleware/tree/main/packages/zod-validator) to make it even easier.
+We do our best to support common TypeScript-enabled validators. If you don't see your validator of choice on the list, please [open an issue in the `honojs/middleware` repo.](https://github.com/honojs/middleware/issues)
+
+
+### Zod Validator Middleware
+
+The [Zod Validator Middleware](https://github.com/honojs/middleware/tree/main/packages/zod-validator) makes it even easier by handling the boilerplate for you!
+
+Like most of our third-party validator middleware, it takes three parameters: the validation **target**, the validation **callback**, and an optional **hook** for manually handling errors or modifying data after validation. 
 
 ::: code-group
 
@@ -275,3 +283,33 @@ const route = app.post(
   }
 )
 ```
+
+## How it works
+
+Validator uses `HonoRequest.addValidatedData` to set valid data in `Context`, making it available in your handler through `c.req.valid`. While the JavaScript implementation might seem straightforward, [`hono/validator` relies on non-trivial generics](https://github.com/honojs/hono/blob/eb86162a9a4472ef86329efe27007caf0afb9284/src/validator/validator.ts) to share validated data types with your handler.
+
+::: warning
+While `c.req.addValidatedData` is a public method, it **must** be used in properly-typed middleware. When used on its own, you will get a type error.
+
+```typescript
+app.get(
+  "/",
+  validator('form', /** Your validation hook */),
+  async (c, next) => {
+    c.req.addValidatedData('form', {
+      timestamp: new Date(),
+      // `addValidatedData` will overwrite target data
+      ...c.req.valid('form'),
+    });
+
+    await next();
+  },
+  async (c) => {
+    // Type Error: Argument of type 'string' is not 
+    // assignable to parameter of type 'never'
+    const body = c.req.valid('form');
+    // ...
+  },
+);
+```
+:::

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -294,12 +294,9 @@ While `c.req.addValidatedData` is a public method, it **must** be used in proper
 ```typescript
 app.get(
   "/",
-  validator('form', /** Your validation hook */),
   async (c, next) => {
     c.req.addValidatedData('form', {
       timestamp: new Date(),
-      // `addValidatedData` will overwrite target data
-      ...c.req.valid('form'),
     });
 
     await next();
@@ -312,4 +309,6 @@ app.get(
   },
 );
 ```
+
+Also note that the method **overwrites** the target data, if any. If you are validating data with `validator` or third-party validation middleware, you must spread in any of the original data you want to keep.
 :::

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -293,7 +293,7 @@ While `c.req.addValidatedData` is a public method, it **must** be used in proper
 
 ```typescript
 app.get(
-  "/",
+  '/',
   async (c, next) => {
     c.req.addValidatedData('form', {
       timestamp: new Date(),

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -297,17 +297,17 @@ app.get(
   async (c, next) => {
     c.req.addValidatedData('form', {
       timestamp: new Date(),
-    });
+    })
 
-    await next();
+    await next()
   },
   async (c) => {
     // Type Error: Argument of type 'string' is not 
     // assignable to parameter of type 'never'
-    const body = c.req.valid('form');
+    const body = c.req.valid('form')
     // ...
   },
-);
+)
 ```
 
 Also note that the method **overwrites** the target data, if any. If you are validating data with `validator` or third-party validation middleware, you must spread in any of the original data you want to keep.

--- a/examples/hono-openapi.md
+++ b/examples/hono-openapi.md
@@ -42,7 +42,10 @@ const responseSchema = v.string()
 
 ### 2. Create Routes
 
-Use `describeRoute` for route documentation and validation:
+Use `describeRoute` for route documentation and response validation:
+
+> [!NOTE]
+> Do not use `describeRoute` to define request requirements (e.g., `query` or `json` body). Hono OpenAPI will document those automatically when you use third-party validator middleware. See the example below.
 
 ```ts
 import { Hono } from 'hono'


### PR DESCRIPTION
### TL;DR
Added some documentation on the `HonoRequest.addValidatedData` method, along with some helpful guidance on validating request data with `hono-openapi`.

I've also made a few other additions/tweaks to provide some additional clarity on validation. Please let me know if those are unhelpful.

_I'm not sure how headings get translated to the table of contents on the right side of the docs UI. Will H3s get read in?_

### Guides/Validation
A user on Discord identified a valid use-case for overriding (validated) request data in middleware. At the same time, the `addValidatedData` method can have unexpected consequences when used without the proper typing. I tried to strike a balance between documenting the method and mis-encouraging its use.
- https://discord.com/channels/1011308539819597844/1347182247337529415/1347229968400257046

_Should I also add an example of how to use the method correctly? It seemed out of scope to me, but I welcome your thoughts!_

### Examples/HonoOpenAPI
A user on Discord ran into some issues using scalar to render openapi docs generated by `hono-openapi`. The issue proved to be an unnecessary specification of the request body in `describeRoute`.
- https://discord.com/channels/1011308539819597844/1343725111601270824/1347232975372419166