### PR TITLE
Add Apitally to third-party middleware page

### DIFF
--- a/docs/middleware/third-party.md
+++ b/docs/middleware/third-party.md
@@ -48,3 +48,4 @@ Most of this middleware leverages external libraries.
 - [Geo](https://github.com/ktkongtong/hono-geo-middleware/tree/main/packages/middleware)
 - [Hono Simple DI](https://github.com/maou-shonen/hono-simple-DI)
 - [Highlight.io](https://www.highlight.io/docs/getting-started/backend-sdk/js/hono)
+- [Apitally (API monitoring & analytics)](https://docs.apitally.io/frameworks/hono)


### PR DESCRIPTION
[Apitally](https://apitally.io/hono) is an API monitoring, analytics and request logging tool that includes a custom middleware for Hono in their SDK.

This PR adds a link to the [setup guide for Hono](https://docs.apitally.io/frameworks/hono) in the Apitally Docs that explains how to install and configure the middleware.