### PR TITLE
Add missing .* in Host routing example to avoid query params in routed path

### DIFF
--- a/docs/api/routing.md
+++ b/docs/api/routing.md
@@ -193,7 +193,7 @@ const app = new Hono({
   getPath: (req) =>
     '/' +
     req.headers.get('host') +
-    req.url.replace(/^https?:\/\/[^/]+(\/[^?]*)/, '$1'),
+    req.url.replace(/^https?:\/\/[^/]+(\/[^?]*).*/, '$1'),
 })
 
 app.get('/www1.example.com/hello', (c) => c.text('hello www1'))


### PR DESCRIPTION
The current sample code for host-header-based path routing (["Routing with host Header value"](https://hono.dev/docs/api/routing#routing-with-host-header-value)) does not replace query params, which leads to surprising (probably unintended?) behavior: QPs end up in the routed path, which means adding any query param breaks routing for that endpoint.

This fixes the regexp to make it more like the ["Routing with hostname"](https://hono.dev/docs/api/routing#routing-with-hostname) example that excludes QPs from the path.