### PR TITLE
fix(docs): correct typo in JSX usage instructions

### DIFF
--- a/docs/guides/jsx.md
+++ b/docs/guides/jsx.md
@@ -40,7 +40,7 @@ For Deno, you have to modify the `deno.json` instead of the `tsconfig.json`:
 ## Usage
 
 :::info
-If you are comming straight from the [Quick Start](/docs/#quick-start), the main file has a `.ts` extension - you need to change it to `.tsx` - otherwise you will not be able to run the application at all. You should additionally modify the `package.json` (or `deno.json` if you are using Deno) to reflect that change (e.g. instead of having `bun run --hot src/index.ts` in dev script, you should have `bun run --hotsrc/index.tsx`).
+If you are comming straight from the [Quick Start](/docs/#quick-start), the main file has a `.ts` extension - you need to change it to `.tsx` - otherwise you will not be able to run the application at all. You should additionally modify the `package.json` (or `deno.json` if you are using Deno) to reflect that change (e.g. instead of having `bun run --hot src/index.ts` in dev script, you should have `bun run --hot src/index.tsx`).
 :::
 
 `index.tsx`:


### PR DESCRIPTION
Fix typo in the example command.