### PR TITLE
fix: added missing export keyword

### DIFF
--- a/docs/getting-started/aws-lambda.md
+++ b/docs/getting-started/aws-lambda.md
@@ -219,5 +219,5 @@ app.get('/stream', async (c) => {
   })
 })
 
-const handler = streamHandle(app)
+export const handler = streamHandle(app)
 ```


### PR DESCRIPTION
Added missing export keyword for the "Lambda response streaming" section. AWS Lambda function will throw an error if the handler is not exported