### PR TITLE
fix(docs): modify import statement to type-only imports explicitly

### DIFF
--- a/docs/guides/rpc.md
+++ b/docs/guides/rpc.md
@@ -50,7 +50,7 @@ export type AppType = typeof route
 On the Client side, import `hc` and `AppType` first.
 
 ```ts
-import { AppType } from '.'
+import type { AppType } from '.'
 import { hc } from 'hono/client'
 ```
 
@@ -388,7 +388,7 @@ You can also use a React Hook library such as [SWR](https://swr.vercel.app).
 import useSWR from 'swr'
 import { hc } from 'hono/client'
 import type { InferRequestType } from 'hono/client'
-import { AppType } from '../functions/api/[[route]]'
+import type { AppType } from '../functions/api/[[route]]'
 
 const App = () => {
   const client = hc<AppType>('/api')


### PR DESCRIPTION
## summary

Modified `import` to [*Type-Only Imports*](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export) explicitly.

```ts
// from
import { AppType } from '.'

// to
import type { AppType } from '.'
```

## details

In most cases, its difference is not a problem.

### conditions that cause problems

If compiler option [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax) is enabled, type import must be written as follows:

```ts
// A. NG
import { AppType } from '.'

// B. OK
import type { AppType } from '.'

// C. it is also OK
import { type AppType } from '.'
```

However, in pattern C, **server-side code may be mixed into client-side** .

### why this happen

It is caused by rewriting rule of TypeScript.

The statement `import { type AppType } from '@/module'` is rewritten into `import {} from '@/module'`.
It means `@/module` will still be imported as a value after compilation.

I created the repository ([Enchan1207/hono_rpc_import_style_differences](https://github.com/Enchan1207/hono_rpc_import_style_differences)) for reproducing its behavior.

The option `verbatimModuleSyntax` is not enabled as default, so it might be nitpick.
