### PR TITLE
docs: add alternative JSX import source configuration for Vite

### DIFF
--- a/docs/guides/jsx-dom.md
+++ b/docs/guides/jsx-dom.md
@@ -280,3 +280,15 @@ There is a small JSX Runtime for Client Components. Using this will result in sm
   }
 }
 ```
+
+Alternatively, you can specify `hono/jsx/dom` in the esbuild transform options in `vite.config.ts`.
+
+```ts
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  esbuild: {
+    jsxImportSource: 'hono/jsx/dom',
+  },
+})
+```


### PR DESCRIPTION
I have added a note on the following page about how to configure `hono/jsx/dom` using the esbuild options in `vite.config.ts`.
https://hono.dev/docs/guides/jsx-dom

I would appreciate it if necessary.
Thank you in advance.
