### PR TITLE
docs: use `html` helper instead of dangerouslySetInnerHTML

### DIFF
--- a/docs/helpers/websocket.md
+++ b/docs/helpers/websocket.md
@@ -140,6 +140,7 @@ ws.addEventListener('open', () => {
 ```tsx
 import { Hono } from 'hono'
 import { createBunWebSocket } from 'hono/bun'
+import { html } from 'hono/html'
 
 const { upgradeWebSocket, websocket } = createBunWebSocket()
 

--- a/docs/helpers/websocket.md
+++ b/docs/helpers/websocket.md
@@ -153,17 +153,15 @@ app.get('/', (c) => {
       </head>
       <body>
         <div id='now-time'></div>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-        const ws = new WebSocket('ws://localhost:3000/ws')
-        const $nowTime = document.getElementById('now-time')
-        ws.onmessage = (event) => {
-          $nowTime.textContent = event.data
-        }
-        `,
-          }}
-        ></script>
+        {html`
+          <script>
+            const ws = new WebSocket('ws://localhost:3000/ws')
+            const $nowTime = document.getElementById('now-time')
+            ws.onmessage = (event) => {
+              $nowTime.textContent = event.data
+            }
+          </script>
+        `}
       </body>
     </html>
   )


### PR DESCRIPTION
is there a reason why dangerouslySetInnerHTML is used here?

I think the formatting and neatness is improved by using the html helper