### PR TITLE
Docs: Add note about Cloudflare's RPC preference over fetch for Durable Objects

### DIFF
--- a/examples/cloudflare-durable-objects.md
+++ b/examples/cloudflare-durable-objects.md
@@ -2,6 +2,8 @@
 
 By using Hono, you can write [Durable Objects](https://developers.cloudflare.com/durable-objects/) application easily.
 
+> **Note:** As of Cloudflare Workers compatibility date `2024-04-03`, it's recommended to use RPC methods instead of the `fetch` handler for Durable Objects. While the example below using Hono's `fetch` handler pattern continues to work, consider using the RPC pattern for new projects. See [Cloudflare's documentation](https://developers.cloudflare.com/durable-objects/best-practices/create-durable-object-stubs-and-send-requests/) for more details.
+
 Hono can handle a `fetch` event of Durable Objects and you can use it with the powerful router.
 
 ```ts


### PR DESCRIPTION
## Description

The current Hono documentation for Cloudflare Durable Objects shows examples using the `fetch` handler pattern. However, as of compatibility date `2024-04-03`, Cloudflare recommends using RPC methods over the `fetch` handler pattern for Durable Objects.

While Hono still works perfectly with the `fetch` handler pattern, it would be helpful to:
1. Add a note about this Cloudflare recommendation
2. Potentially provide an example using both patterns

## Current Documentation
The current example at https://hono.dev/examples/cloudflare-durable-objects shows only the `fetch` handler pattern:

```typescript
export class Counter {
  value: number = 0
  state: DurableObjectState
  app: Hono = new Hono()

  constructor(state: DurableObjectState) {
    // ...
  }

  async fetch(request: Request) {
    return this.app.fetch(request)
  }
}
```

## Suggested Addition

Consider adding a note like:

> **Note:** As of Cloudflare Workers compatibility date `2024-04-03`, it's recommended to use RPC methods instead of the `fetch` handler for Durable Objects. While Hono continues to work with the `fetch` handler pattern shown above, you might want to consider the RPC pattern for new projects. See [Cloudflare's documentation](https://developers.cloudflare.com/durable-objects/best-practices/create-durable-object-stubs-and-send-requests/) for more details.

## Additional Context
- Reference: https://developers.cloudflare.com/durable-objects/best-practices/create-durable-object-stubs-and-send-requests/
- This change only affects projects with compatibility dates >= 2024-04-03
- Both patterns remain functional, but RPC is now considered best practice by Cloudflare

## Impact
This documentation update would help developers make informed decisions about which pattern to use in their Hono applications with Durable Objects.