### PR TITLE
Update cloudflare-workers.md

### DIFF
--- a/docs/getting-started/cloudflare-workers.md
+++ b/docs/getting-started/cloudflare-workers.md
@@ -311,7 +311,7 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          command: deploy --name my-app
+          wranglerVersion: "^3.91.0"
 ```
 
 then edit `wrangler.toml`, and add this code after `compatibility_date` line.

--- a/docs/getting-started/cloudflare-workers.md
+++ b/docs/getting-started/cloudflare-workers.md
@@ -311,6 +311,7 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          command: deploy --name my-app
 ```
 
 then edit `wrangler.toml`, and add this code after `compatibility_date` line.


### PR DESCRIPTION
When using the latest Quick Start script to initialize a new project, only the wrangler.jsonc file is generated by default, and the wrangler.toml file is not included. This can cause GitHub Actions automated deployment to fail with the following error:


```
You need to provide a name when publishing a worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`
```

To resolve this issue, you have two options:

Add a wrangler.toml file to the root of your project with the following content:
1. Add a wrangler.toml file to the root of your project with the following content:
  ```
  name = "my-app"
  ```
2. Modify the `.github/workflows/deploy.yml` file to explicitly specify the deployment command:
  ```yml
  jobs:
    deploy:
      runs-on: ubuntu-latest
      name: Deploy
      steps:
        - uses: actions/checkout@v4
        - name: Deploy
          uses: cloudflare/wrangler-action@v3
          with:
            apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
            command: deploy --name my-app
  ```

Reference：
- https://github.com/cloudflare/wrangler-action/blob/v3/action.yml#L38