### PR TITLE
Docs: Add clear documentation for making the client send cookies with every request

### DIFF
--- a/docs/guides/rpc.md
+++ b/docs/guides/rpc.md
@@ -80,6 +80,25 @@ if (res.ok) {
 }
 ```
 
+### Cookies
+
+To make the client send cookies with every request, add `{ 'init': { 'credentials": 'include' } }` to the options when you're creating the client.
+```ts
+// client.ts
+const client = hc<AppType>('http://localhost:8787/', {
+  'init': {
+    'credentials": 'include',
+  }
+})
+
+// This request will now include any cookies you might have set
+const res = await client.posts.$get({
+  query: {
+    id: '123',
+  },
+})
+```
+
 ## Status code
 
 If you explicitly specify the status code, such as `200` or `404`, in `c.json()`. It will be added as a type for passing to the client.


### PR DESCRIPTION
The documentation was not very clear on how to include cookies with every request. 
It took me a while to figure it out.

I hope adding this to the documentation saves another developer a headache.