### PR TITLE
docs: fix typo in RPC client credentials example

### DIFF
--- a/docs/guides/rpc.md
+++ b/docs/guides/rpc.md
@@ -87,7 +87,7 @@ To make the client send cookies with every request, add `{ 'init': { 'credential
 // client.ts
 const client = hc<AppType>('http://localhost:8787/', {
   'init': {
-    'credentials": 'include',
+    'credentials': 'include',
   }
 })
 


### PR DESCRIPTION
Fixed a syntax error in the RPC guide where the credentials key in the client configuration example had incorrect quotation marks.