### PR TITLE
Update aws-lambda.md

### DIFF
--- a/docs/getting-started/aws-lambda.md
+++ b/docs/getting-started/aws-lambda.md
@@ -20,6 +20,7 @@ mkdir my-app
 cd my-app
 cdk init app -l typescript
 npm i hono
+npm i -D esbuild
 mkdir lambda
 touch lambda/index.ts
 ```
@@ -29,6 +30,7 @@ mkdir my-app
 cd my-app
 cdk init app -l typescript
 yarn add hono
+yarn add -D hono
 mkdir lambda
 touch lambda/index.ts
 ```
@@ -38,6 +40,7 @@ mkdir my-app
 cd my-app
 cdk init app -l typescript
 pnpm add hono
+pnpm add -D esbuild
 mkdir lambda
 touch lambda/index.ts
 ```
@@ -47,6 +50,7 @@ mkdir my-app
 cd my-app
 cdk init app -l typescript
 bun add hono
+bun add -D esbuild
 mkdir lambda
 touch lambda/index.ts
 ```
@@ -76,7 +80,6 @@ Edit `lib/my-app-stack.ts`.
 import * as cdk from 'aws-cdk-lib'
 import { Construct } from 'constructs'
 import * as lambda from 'aws-cdk-lib/aws-lambda'
-import * as apigw from 'aws-cdk-lib/aws-apigateway'
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs'
 
 export class MyAppStack extends cdk.Stack {
@@ -86,14 +89,15 @@ export class MyAppStack extends cdk.Stack {
     const fn = new NodejsFunction(this, 'lambda', {
       entry: 'lambda/index.ts',
       handler: 'handler',
-      runtime: lambda.Runtime.NODEJS_20_X,
+      runtime: lambda.Runtime.NODEJS_22_X,
     })
-    fn.addFunctionUrl({
+    const fnUrl = fn.addFunctionUrl({
       authType: lambda.FunctionUrlAuthType.NONE,
     })
-    new apigw.LambdaRestApi(this, 'myapi', {
-      handler: fn,
+    new cdk.CfnOutput(this, 'lambdaUrl', {
+      value: fnUrl.url!
     })
+    
   }
 }
 ```

--- a/docs/getting-started/aws-lambda.md
+++ b/docs/getting-started/aws-lambda.md
@@ -30,7 +30,7 @@ mkdir my-app
 cd my-app
 cdk init app -l typescript
 yarn add hono
-yarn add -D hono
+yarn add -D esbuild
 mkdir lambda
 touch lambda/index.ts
 ```
@@ -97,7 +97,6 @@ export class MyAppStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'lambdaUrl', {
       value: fnUrl.url!
     })
-    
   }
 }
 ```


### PR DESCRIPTION
+ Add esbuild as a dev dependency so docker doesn't need to be running for `cdk deploy`
+ Remove APIG, having both a lambda function url and APIG is unnecessary
+ Emit function url endpoint
+ Update node to 22