### PR TITLE
Update cloudflare-pages.md - Add missing basePath method

### DIFF
--- a/docs/getting-started/cloudflare-pages.md
+++ b/docs/getting-started/cloudflare-pages.md
@@ -393,7 +393,7 @@ type Env = {
   }
 }
 
-const app = new Hono<Env>()
+const app = new Hono<Env>().basePath("/api");
 
 app.get('/hello', (c) => {
   return c.json({


### PR DESCRIPTION
- Add missing 'basePath' in the example provided.

The example clearly states the typical use-case of having the functions under the `/api` route, however if you do that, you'll need to add `.basePath("/api");` to the `new Hono` instruction.