### PR TITLE
Improve alt text.

### DIFF
--- a/docs/concepts/benchmarks.md
+++ b/docs/concepts/benchmarks.md
@@ -92,41 +92,41 @@ Let's see the results.
 
 The following screenshots show the results on Node.js.
 
-![bench](/images/bench01.png)
+![](/images/bench01.png)
 
-![bench](/images/bench02.png)
+![](/images/bench02.png)
 
-![bench](/images/bench03.png)
+![](/images/bench03.png)
 
-![bench](/images/bench04.png)
+![](/images/bench04.png)
 
-![bench](/images/bench05.png)
+![](/images/bench05.png)
 
-![bench](/images/bench06.png)
+![](/images/bench06.png)
 
-![bench](/images/bench07.png)
+![](/images/bench07.png)
 
-![bench](/images/bench08.png)
+![](/images/bench08.png)
 
 ### On Bun
 
 The following screenshots show the results on Bun.
 
-![bench](/images/bench09.png)
+![](/images/bench09.png)
 
-![bench](/images/bench10.png)
+![](/images/bench10.png)
 
-![bench](/images/bench11.png)
+![](/images/bench11.png)
 
-![bench](/images/bench12.png)
+![](/images/bench12.png)
 
-![bench](/images/bench13.png)
+![](/images/bench13.png)
 
-![bench](/images/bench14.png)
+![](/images/bench14.png)
 
-![bench](/images/bench15.png)
+![](/images/bench15.png)
 
-![bench](/images/bench16.png)
+![](/images/bench16.png)
 
 ## Cloudflare Workers
 

--- a/docs/concepts/middleware.md
+++ b/docs/concepts/middleware.md
@@ -4,7 +4,7 @@ We call the primitive that returns `Response` as "Handler".
 "Middleware" is executed before and after the Handler and handles the `Request` and `Response`.
 It's like an onion structure.
 
-![Onion](/images/onion.png)
+![](/images/onion.png)
 
 For example, we can write the middleware to add the "X-Response-Time" header as follows.
 

--- a/docs/concepts/routers.md
+++ b/docs/concepts/routers.md
@@ -12,12 +12,12 @@ Although this is called "RegExp" it is not an Express-like implementation using 
 They are using linear loops.
 Therefore, regular expression matching will be performed for all routes and the performance will be degraded as you have more routes.
 
-![Router Linear](/images/router-linear.jpg)
+![](/images/router-linear.jpg)
 
 Hono's RegExpRouter turns the route pattern into "one large regular expression".
 Then it can get the result with one-time matching.
 
-![Router RegExp](/images/router-regexp.jpg)
+![](/images/router-regexp.jpg)
 
 This works faster than methods that use tree-based algorithms such as radix-tree in most cases.
 
@@ -26,7 +26,7 @@ This works faster than methods that use tree-based algorithms such as radix-tree
 **TrieRouter** is the router using the Trie-tree algorithm.
 It does not use linear loops as same as RegExpRouter.
 
-![Router Tree](/images/router-tree.jpg)
+![](/images/router-tree.jpg)
 
 This router is not as fast as the RegExpRouter, but it is much faster than the Express router.
 TrieRouter supports all patterns though RegExpRouter does not.

--- a/docs/concepts/stacks.md
+++ b/docs/concepts/stacks.md
@@ -39,7 +39,7 @@ app.get('/hello', (c) => {
 
 Validate with Zod to receive the value of the query parameter.
 
-![SC](/images/sc01.gif)
+![](/images/sc01.gif)
 
 ```ts
 import { zValidator } from '@hono/zod-validator'
@@ -98,7 +98,7 @@ Next. The client-side implementation.
 Create a client object by passing the `AppType` type to `hc` as generics.
 Then, magically, completion works and the endpoint path and request type are suggested.
 
-![SC](/images/sc03.gif)
+![](/images/sc03.gif)
 
 ```ts
 import { AppType } from './server'
@@ -114,7 +114,7 @@ const res = await client.hello.$get({
 
 The `Response` is compatible with the fetch API, but the data that can be retrieved with `json()` has a type.
 
-![SC](/images/sc04.gif)
+![](/images/sc04.gif)
 
 ```ts
 const data = await res.json()
@@ -123,7 +123,7 @@ console.log(`${data.message}`)
 
 Sharing API specifications means that you can be aware of server-side changes.
 
-![SS](/images/ss03.png)
+![](/images/ss03.png)
 
 ## With React
 

--- a/docs/guides/rpc.md
+++ b/docs/guides/rpc.md
@@ -577,7 +577,7 @@ However, we have some tips to mitigate this issue.
 
 If your backend is separate from the frontend and lives in a different directory, you need to ensure that the Hono versions match. If you use one Hono version on the backend and another on the frontend, you'll run into issues such as "_Type instantiation is excessively deep and possibly infinite_".
 
-![hono-version-mismatch](https://github.com/user-attachments/assets/e4393c80-29dd-408d-93ab-d55c11ccca05)
+![](https://github.com/user-attachments/assets/e4393c80-29dd-408d-93ab-d55c11ccca05)
 
 #### TypeScript project references
 

--- a/docs/helpers/css.md
+++ b/docs/helpers/css.md
@@ -216,4 +216,4 @@ app.get('/', (c) => {
 
 If you use VS Code, you can use [vscode-styled-components](https://marketplace.visualstudio.com/items?itemName=styled-components.vscode-styled-components) for Syntax highlighting and IntelliSense for css tagged literals.
 
-![VS Code](/images/css-ss.png)
+![](/images/css-ss.png)

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,7 +92,7 @@ Do you want to see more? See [Who is using Hono in production?](https://github.c
 
 A demonstration to create an application for Cloudflare Workers with Hono.
 
-![Demo](/images/sc.gif)
+![A gif showing a hono app being created quickly with fast iteration.](/images/sc.gif)
 
 ## Ultrafast
 
@@ -202,7 +202,7 @@ Moreover, Hono is written in TypeScript. Hono has "**Types**".
 
 For example, the path parameters will be literal types.
 
-![SS](/images/ss.png)
+![A screenshot showing Hono having proper literal typing when URL parameters. The URL "/entry/:date/:id" allows for request parameters to be "date" or "id"](/images/ss.png)
 
 And, the Validator and Hono Client `hc` enable the RPC mode. In RPC mode,
 you can use your favorite validator such as Zod and easily share server-side API specs with the client and build type-safe applications.

--- a/docs/middleware/builtin/timing.md
+++ b/docs/middleware/builtin/timing.md
@@ -62,7 +62,7 @@ app.use(
 
 ## Result
 
-![Example timing output](/images/timing-example.png)
+![](/images/timing-example.png)
 
 ## Options
 

--- a/examples/pylon.md
+++ b/examples/pylon.md
@@ -135,7 +135,7 @@ recommended to use the Pylon Playground, which is a web-based GraphQL IDE that a
 2. Open the Pylon Playground in your browser by navigating to `http://localhost:3000/graphql`.
 3. Write your GraphQL query or mutation in the left panel.
 
-![Pylon Playground](/images/pylon-example.png)
+![](/images/pylon-example.png)
 
 ## Get access to the Hono context
 

--- a/index.md
+++ b/index.md
@@ -16,7 +16,12 @@ hero:
   tagline: Fast, lightweight, built on Web Standards. Support for any JavaScript runtime.
   image:
     src: /images/code.webp
-    alt: Hono
+    alt: "An example of code for Hono. \
+         import { Homo } from 'hono' \
+         const app = new Hono() \
+         app.get('/', (c) => c.text('Hello Hono!')) \
+         
+         export default app"
   actions:
     - theme: brand
       text: Get Started
@@ -54,6 +59,7 @@ onMounted(() => {
     const images = document.querySelectorAll('.VPImage.image-src')
     images.forEach((img) => {
       img.src = '/images/hono-kawaii.png'
+      img.alt = 'A Kawai Version of the Hono Logo. The first "o" is replaced with a flame, with japanese characters in the bottom right, and a JSX fragment closing tag above the flame.'
       img.classList.add("kawaii")
     })
   }


### PR DESCRIPTION
This pull request adds proper alt text to several images, while removing alt text from all images where the alt text is simply the filename/other nondescript values. 

This should make it easier to find when alt text was omitted.

I currently don't have the time to write alt text for images, but this should be a good base.

It should also be noted that it is reccomended to avoid images which just show text, for example: the code block in /index.md or the benchmarks in /docs/concepts/benchmarks.md