### PR TITLE
Update better-auth.md

### DIFF
--- a/examples/better-auth.md
+++ b/examples/better-auth.md
@@ -60,10 +60,8 @@ export const auth = betterAuth({
 })
 
 export type AuthType = {
-  Variables: {
     user: typeof auth.$Infer.Session.user | null
     session: typeof auth.$Infer.Session.session | null
-  }
 }
 ```
 
@@ -110,7 +108,7 @@ import { Hono } from "hono";
 import type { AuthType } from "../lib/auth"
 import auth from "@/routes/auth";
 
-const app = new Hono<{ Bindings: AuthType }>({
+const app = new Hono<{ Variables: AuthType }>({
   strict: false,
 });
 


### PR DESCRIPTION
### Summary

This PR simplifies the `AuthType` definition and updates the way we type the Hono app.

### What Changed

* Changed `AuthType` from `{ Variables: { session, user } }` to just `{ session, user }`.
* Updated Hono app creation to use `Hono<AuthType>()` instead of `Hono<{ Bindings: ..., Variables: AuthType }>()`.

### Why

The previous typing structure prevented TypeScript from correctly inferring types when using `c.set("session", session)` and `c.get("session")`. This refactor ensures that session and user values are properly typed and accessible within the context.