### PR TITLE
docs(example): fix route wildcard from '/api/**' to '/api/*'

### DIFF
--- a/examples/better-auth-on-cloudflare.md
+++ b/examples/better-auth-on-cloudflare.md
@@ -335,7 +335,7 @@ import { auth } from './lib/better-auth';
 
 const app = new Hono<{ Bindings: CloudflareBindings }>();
 
-app.on(['GET', 'POST'], '/api/**', (c) => {
+app.on(['GET', 'POST'], '/api/*', (c) => {
   return auth(c.env).handler(c.req.raw);
 });
 


### PR DESCRIPTION
🙏 I mistakenly assumed that Hono supports the /** pattern because I saw it used in other documentation I was referencing.
To avoid confusion, I’ve updated the guide accordingly.