### PR TITLE
docs(v4.8): add headerName option to JWT middleware

### DIFF
--- a/docs/middleware/builtin/jwt.md
+++ b/docs/middleware/builtin/jwt.md
@@ -1,7 +1,7 @@
 # JWT Auth Middleware
 
 The JWT Auth Middleware provides authentication by verifying the token with JWT.
-The middleware will check for an `Authorization` header if the `cookie` option is not set.
+The middleware will check for an `Authorization` header if the `cookie` option is not set. You can customize the header name using the `headerName` option.
 
 :::info
 The Authorization header sent from the client must have a specified scheme.
@@ -82,7 +82,20 @@ If this value is set, then the value is retrieved from the cookie header using t
 
 ### <Badge type="info" text="optional" /> alg: `string`
 
-An algorithm type that is used for verifying.  
-The default is `HS256`.
+An algorithm type that is used for verifying. The default is `HS256`.
 
 Available types are `HS256` | `HS384` | `HS512` | `RS256` | `RS384` | `RS512` | `PS256` | `PS384` | `PS512` | `ES256` | `ES384` | `ES512` | `EdDSA`.
+
+### <Badge type="info" text="optional" /> headerName: `string`
+
+The name of the header to look for the JWT token. The default is `Authorization`.
+
+```ts
+app.use(
+  '/auth/*',
+  jwt({
+    secret: 'it-is-very-secret',
+    headerName: 'x-custom-auth-header',
+  })
+)
+```


### PR DESCRIPTION
Add documentation for custom header location feature in JWT middleware.