### PR TITLE
docs(v4.8): add function support to CORS allowMethods

### DIFF
--- a/docs/middleware/builtin/cors.md
+++ b/docs/middleware/builtin/cors.md
@@ -61,15 +61,32 @@ app.use(
 )
 ```
 
+Dynamic allowed methods based on origin:
+
+```ts
+app.use(
+  '/api5/*',
+  cors({
+    origin: (origin) =>
+      origin === 'https://example.com' ? origin : '*',
+    // `c` is a `Context` object
+    allowMethods: (origin, c) =>
+      origin === 'https://example.com'
+        ? ['GET', 'HEAD', 'POST', 'PATCH', 'DELETE']
+        : ['GET', 'HEAD'],
+  })
+)
+```
+
 ## Options
 
 ### <Badge type="info" text="optional" /> origin: `string` | `string[]` | `(origin:string, c:Context) => string`
 
 The value of "_Access-Control-Allow-Origin_" CORS header. You can also pass the callback function like `origin: (origin) => (origin.endsWith('.example.com') ? origin : 'http://example.com')`. The default is `*`.
 
-### <Badge type="info" text="optional" /> allowMethods: `string[]`
+### <Badge type="info" text="optional" /> allowMethods: `string[]` | `(origin:string, c:Context) => string[]`
 
-The value of "_Access-Control-Allow-Methods_" CORS header. The default is `['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH']`.
+The value of "_Access-Control-Allow-Methods_" CORS header. You can also pass a callback function to dynamically determine allowed methods based on the origin. The default is `['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH']`.
 
 ### <Badge type="info" text="optional" /> allowHeaders: `string[]`
 


### PR DESCRIPTION
Add documentation for function-based allowMethods in CORS middleware, enabling dynamic method restrictions based on origin.