### PR TITLE
docs(v4.8): add fire() function and deprecate app.fire()

### DIFF
--- a/docs/api/hono.md
+++ b/docs/api/hono.md
@@ -60,6 +60,10 @@ app.onError((err, c) => {
 
 ## fire()
 
+::: warning
+**`app.fire()` is deprecated**. Use `fire()` from `hono/service-worker` instead. See the [Service Worker documentation](/docs/getting-started/service-worker) for details.
+:::
+
 `app.fire()` automatically adds a global `fetch` event listener.
 
 This can be useful for environments that adhere to the [Service Worker API](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API), such as [non-ES module Cloudflare Workers](https://developers.cloudflare.com/workers/reference/migrate-to-module-workers/).

--- a/docs/getting-started/service-worker.md
+++ b/docs/getting-started/service-worker.md
@@ -126,6 +126,20 @@ app.get('/', (c) => c.text('Hello World'))
 self.addEventListener('fetch', handle(app))
 ```
 
+### Using `fire()`
+
+The `fire()` function automatically calls `addEventListener('fetch', handle(app))` for you, making the code more concise.
+
+```ts
+import { Hono } from 'hono'
+import { fire } from 'hono/service-worker'
+
+const app = new Hono().basePath('/sw')
+app.get('/', (c) => c.text('Hello World'))
+
+fire(app)
+```
+
 ## 3. Run
 
 Start the development server.


### PR DESCRIPTION
Add documentation for the new fire() function from hono/service-worker and deprecate app.fire() with migration instructions.