### PR TITLE
docs: add theme-color meta tag

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -395,6 +395,7 @@ export default defineConfig({
         content: 'https://hono.dev/images/hono-title.png',
       },
     ],
+    ['meta', { name: 'theme-color', content: '#E36002' }],
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'twitter:domain', content: 'hono.dev' }],
     [


### PR DESCRIPTION
Add a [theme-color meta tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name/theme-color) with Hono's orange branding.

I personally think the docs site looks slick with the orange accent on compatible devices, but feel free to reject this if you feel otherwise.