### PR TITLE
docs: fix typos in node.js docs

### DIFF
--- a/docs/getting-started/nodejs.md
+++ b/docs/getting-started/nodejs.md
@@ -83,17 +83,17 @@ app.get('/', (c) => c.text('Hello Node.js!'))
 serve(app)
 ```
 
-+If you want to gracefully shut down the server, write it like this:
+If you want to gracefully shut down the server, write it like this:
 
 ```ts
 const server = serve(app)
 
 // graceful shutdown
-process.on("SIGINT", () => {
+process.on('SIGINT', () => {
   server.close()
   process.exit(0)
 })
-process.on("SIGTERM", () => {
+process.on('SIGTERM', () => {
   server.close((err) => {
     if (err) {
       console.error(err)


### PR DESCRIPTION
Remove a `+` that might have been a typo

Update the quotes to be single quotes similar to the rest of this doc.