### PR TITLE
feat(jwt): added docs for `honojs/hono#4253` - added validation for the isuer (`iss`) claim

### DIFF
--- a/docs/helpers/jwt.md
+++ b/docs/helpers/jwt.md
@@ -66,6 +66,7 @@ verify(
   token: string,
   secret: string,
   alg?: 'HS256';
+  issuer?: string | RegExp;
 ): Promise<any>;
 
 ```
@@ -97,6 +98,10 @@ The secret key used for JWT verification or signing.
 #### <Badge type="info" text="optional" /> alg: [AlgorithmTypes](#supported-algorithmtypes)
 
 The algorithm used for JWT signing or verification. The default is HS256.
+
+#### <Badge type="info" text="optional" /> issuer: `string | RegExp`
+
+The expected issuer used for JWT verification.
 
 ## `decode()`
 
@@ -138,6 +143,7 @@ When verifying a JWT token, the following payload validations are performed:
 - `exp`: The token is checked to ensure it has not expired.
 - `nbf`: The token is checked to ensure it is not being used before a specified time.
 - `iat`: The token is checked to ensure it is not issued in the future.
+- `iss`: The token is checked to ensure it has been issued by a trusted issuer.
 
 Please ensure that your JWT payload includes these fields, as an object, if you intend to perform these checks during verification.
 
@@ -150,6 +156,7 @@ The module also defines custom error types to handle JWT-related errors.
 - `JwtTokenNotBefore`: Indicates that the token is being used before its valid date.
 - `JwtTokenExpired`: Indicates that the token has expired.
 - `JwtTokenIssuedAt`: Indicates that the "iat" claim in the token is incorrect.
+- `JwtTokenIssuer`: Indicates that the "iss" claim in the token is incorrect.
 - `JwtTokenSignatureMismatched`: Indicates a signature mismatch in the token.
 
 ## Supported AlgorithmTypes

--- a/docs/middleware/builtin/jwt.md
+++ b/docs/middleware/builtin/jwt.md
@@ -46,12 +46,13 @@ app.use(
   '/auth/*',
   jwt({
     secret: 'it-is-very-secret',
+    issuer: 'my-trusted-issuer',
   })
 )
 
 app.get('/auth/page', (c) => {
   const payload = c.get('jwtPayload')
-  return c.json(payload) // eg: { "sub": "1234567890", "name": "John Doe", "iat": 1516239022 }
+  return c.json(payload) // eg: { "sub": "1234567890", "name": "John Doe", "iat": 1516239022, "iss": "my-trusted-issuer" }
 })
 ```
 
@@ -99,3 +100,7 @@ app.use(
   })
 )
 ```
+
+### <Badge type="info" text="optional" /> issuer: `string | RegExp`
+
+The expected issuer used for token verification. The `iss` claim will **not** be checked if this isn't set.


### PR DESCRIPTION
Adds docs for the [`honojs/hono#4253`](https://github.com/honojs/hono/pull/4253) pull request.

`feat(jwt): added validation for the issuer (iss) claim`

> This adds validation for the issuer claim (iss),
> with support for simple strings and complex Regex patterns.
>
> As this only verifies when the user has added an expected issuer, this isn't a breaking change and won't impact usage.
> You can however opt-in to issuer verification by simply setting the issuer option to your expected issuer.
