### PR TITLE
docs: fix undefined type in cloudflare-durable-objects.md

### DIFF
--- a/examples/cloudflare-durable-objects.md
+++ b/examples/cloudflare-durable-objects.md
@@ -15,7 +15,7 @@ You can use Hono as the router in your Cloudflare Worker, calling RPCs (Remote P
 import { DurableObject } from 'cloudflare:workers'
 import { Hono } from 'hono'
 
-export class Counter extends DurableObject {
+export class Counter<Env = unknown> extends DurableObject {
   // In-memory state
   value = 0
 


### PR DESCRIPTION
Add `<Env = unknown>` to Counter declaration so that `Env` isn't undefined on the constructor line below.

I encountered that after copy & pasting the example and running the cf-typegen script (`wrangler types --env-interface CloudflareBindings`)