### PR TITLE
Uses performance.now instead of Date.now

### DIFF
--- a/docs/concepts/middleware.md
+++ b/docs/concepts/middleware.md
@@ -13,9 +13,9 @@ import { Hono } from 'hono'
 const app = new Hono()
 // ---cut---
 app.use(async (c, next) => {
-  const start = Date.now()
+  const start = performance.now()
   await next()
-  const end = Date.now()
+  const end = performance.now()
   c.res.headers.set('X-Response-Time', `${end - start}`)
 })
 ```


### PR DESCRIPTION
This PR fixes #699 

The PR replaces the use of `Date.now()` with `performance.now()` (see issue for details)