### PR TITLE
docs(guides/rpc): add guide for `parseResponse()`

### DIFF
--- a/docs/guides/rpc.md
+++ b/docs/guides/rpc.md
@@ -459,13 +459,13 @@ type ResType = InferResponseType<typeof $post>
 
 ## Automatic response parsing with type-safety helper
 
-You can use `hcParse()` helper to easily parse a Response from `hc` with type-safety.
+You can use `parseResponse()` helper to easily parse a Response from `hc` with type-safety.
 
 ```ts
-import { hcParse, DetailedError } from 'hono/client'
+import { parseResponse, DetailedError } from 'hono/client'
 
-const res = await hcParse(client.hello.$get())
-  .catch((e: DetailedError) => { console.error(e) }) // hcParse will also automatically throw an error if the response is not `ok`.
+const res = await parseResponse(client.hello.$get())
+  .catch((e: DetailedError) => { console.error(e) }) // `parseResponse` will also automatically throw an error if the response is not `ok`.
 ```
 
 ## Using SWR


### PR DESCRIPTION
Related honojs/hono#4314

Adding guide for `parseResponse` if it's approved.