### PR TITLE
docs: add metadata hoisting section to JSX guide

### DIFF
--- a/docs/guides/jsx.md
+++ b/docs/guides/jsx.md
@@ -82,6 +82,40 @@ app.get('/', (c) => {
 export default app
 ```
 
+## Metadata hoisting
+
+You can write document metadata tags such as `<title>`, `<link>`, and `<meta>` directly inside your components. These tags will be automatically hoisted to the `<head>` section of the document. This is especially useful when the `<head>` element is rendered far from the component that determines the appropriate metadata.
+
+```tsx
+import { Hono } from 'hono'
+
+const app = new Hono()
+
+app.use('*', async (c, next) => {
+  c.setRenderer((content) => {
+    return c.html(
+      <html>
+        <head></head>
+        <body>{content}</body>
+      </html>
+    )
+  })
+  await next()
+})
+
+app.get('/about', (c) => {
+  return c.render(
+    <>
+      <title>About Page</title>
+      <meta name='description' content='This is the about page.' />
+      about page content
+    </>
+  )
+})
+
+export default app
+```
+
 ## Fragment
 
 Use Fragment to group multiple elements without adding extra nodes:


### PR DESCRIPTION
Added a section about metadata hoisting[^1][^2] to the JSX guide.

[^1]: https://react.dev/blog/2024/12/05/react-19#support-for-metadata-tags  
[^2]: https://github.com/honojs/hono/pull/2960