### PR TITLE
docs(fastly): use `fire()` from `hono/service-worker` instead of `app.fire()`

### DIFF
--- a/docs/getting-started/fastly.md
+++ b/docs/getting-started/fastly.md
@@ -67,11 +67,13 @@ Edit `src/index.ts`:
 ```ts
 // src/index.ts
 import { Hono } from 'hono'
+import { fire } from 'hono/service-worker'
+
 const app = new Hono()
 
 app.get('/', (c) => c.text('Hello Fastly!'))
 
-app.fire()
+fire(app)
 ```
 
 ## 3. Run


### PR DESCRIPTION
Related to https://github.com/honojs/starter/pull/102