### PR TITLE
Add explain for middleware in Deno

### DIFF
--- a/docs/getting-started/deno.md
+++ b/docs/getting-started/deno.md
@@ -213,6 +213,14 @@ deno test hello.ts
   }
 }
 ```
+To use middleware you need to use the [Deno directory](https://docs.deno.com/runtime/fundamentals/configuration/#custom-path-mappings) syntaxt in the import
+```json
+{
+  "imports": {
+    "hono/": "npm:/hono/"
+  }
+}
+```
 
 You can use either `npm:hono` or `jsr:@hono/hono`.
 


### PR DESCRIPTION
This PR add explanation for import for middleware.
For a while I thought the only way to import them was to duplicate the Deno import line for each file, but there is a better way.
I found it today in drizzle doc here : https://orm.drizzle.team/docs/tutorials/drizzle-with-supabase-edge-functions#setup-imports