### PR TITLE
docs(rpc): typescript complaining about unused variable

### DIFF
--- a/docs/guides/rpc.md
+++ b/docs/guides/rpc.md
@@ -610,8 +610,7 @@ import { app } from './app'
 import { hc } from 'hono/client'
 
 // this is a trick to calculate the type when compiling
-const client = hc<typeof app>('')
-export type Client = typeof client
+export type Client = ReturnType<typeof hc<typeof routes>>;
 
 export const hcWithType = (...args: Parameters<typeof hc>): Client =>
   hc<typeof app>(...args)


### PR DESCRIPTION
When using the previous implementation, typescript complains about the variable being only used as a type.