### PR TITLE
docs(validation): use `import * as z from 'zod'` for broader toolchain

### DIFF
--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -192,7 +192,7 @@ bun add zod
 Import `z` from `zod`.
 
 ```ts
-import { z } from 'zod'
+import * as z from 'zod'
 ```
 
 Write your schema.


### PR DESCRIPTION
# Switch Zod import to namespace form for compatibility

This updates the “With Zod” examples to use:

```ts
import * as z from "zod"
```

## Why

Named import `import { z } from "zod"` has produced real-world failures in some stacks and TS/bundler configurations, e.g.:

* **TypeScript error:** “Module '"zod"' has no exported member 'z'.” (common when module resolution settings don’t line up).
  [[colinhacks/zod#3739](https://github.com/colinhacks/zod/issues/3739)](https://github.com/colinhacks/zod/issues/3739)
* **Webpack/bundler error:** “export 'z' (imported as 'z') was not found in 'zod' (module has no exports)” — workarounds exist, but the namespace form avoids the pitfall.
  [[colinhacks/zod#2085](https://github.com/colinhacks/zod/issues/2085)](https://github.com/colinhacks/zod/issues/2085)
* **Recent bundlers (Turbopack/Vite) regressions:** reports indicate named imports can trip bundling; switching to the namespace import is a recommended workaround.
  [[colinhacks/zod#5095](https://github.com/colinhacks/zod/issues/5095)](https://github.com/colinhacks/zod/issues/5095)

## Precedent

Zod’s own docs and README primarily demonstrate the namespace import, which also keeps examples consistent with the wider ecosystem:

* [[Official Zod docs](https://zod.dev/)](https://zod.dev/)
* [[Zod GitHub repo](https://github.com/colinhacks/zod)](https://github.com/colinhacks/zod)
* [[npm package page](https://www.npmjs.com/package/zod)](https://www.npmjs.com/package/zod)

---

This is a **documentation-only change**; no behavior changes. ✅