### PR TITLE
docs: clarify `HTTPException` docs

### DIFF
--- a/docs/api/exception.md
+++ b/docs/api/exception.md
@@ -1,36 +1,30 @@
-# Exception
+# HTTPException
 
-When a fatal error occurs, such as authentication failure, an HTTPException must be thrown.
+When a fatal error occurs, Hono (and many ecosystem middleware) will throw an `HTTPException`. This is a custom Hono `Error` that simplifies [returning error responses](#handling-httpexceptions).
 
-## throw HTTPException
+## Throwing HTTPExceptions
 
-This example throws an HTTPException from the middleware.
+You can throw your own HTTPExceptions by specifying a status code, and either a message or a custom response.
+
+### Custom Message
+
+For basic `text` responses, just set a the error `message`.
 
 ```ts twoslash
-import { Hono } from 'hono'
-const app = new Hono()
-declare const authorized: boolean
-// ---cut---
 import { HTTPException } from 'hono/http-exception'
 
-// ...
-
-app.post('/auth', async (c, next) => {
-  // authentication
-  if (authorized === false) {
-    throw new HTTPException(401, { message: 'Custom error message' })
-  }
-  await next()
-})
+throw new HTTPException(401, { message: 'Unauthorized' })
 ```
 
-You can specify the response to be returned back to the user.
+### Custom Response
+
+For other response types, or to set response headers, use the `res` option. _Note that the status passed to the constructor is the one used to create responses._
 
 ```ts twoslash
 import { HTTPException } from 'hono/http-exception'
 
 const errorResponse = new Response('Unauthorized', {
-  status: 401,
+  status: 401, // this gets ignored
   headers: {
     Authenticate: 'error="invalid_token"',
   },
@@ -39,9 +33,30 @@ const errorResponse = new Response('Unauthorized', {
 throw new HTTPException(401, { res: errorResponse })
 ```
 
-## Handling HTTPException
+### Cause
 
-You can handle the thrown HTTPException with `app.onError`.
+In either case, you can use the [`cause`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) option to add arbitrary data to the HTTPException.
+
+```ts twoslash
+import { Hono, Context } from 'hono'
+import { HTTPException } from 'hono/http-exception'
+const app = new Hono()
+declare const message: string
+declare const authorize: (c: Context) => Promise<void>
+// ---cut---
+app.post('/login', async (c) => {
+  try {
+    await authorize(c)
+  } catch (cause) {
+    throw new HTTPException(401, { message, cause })
+  }
+  return c.redirect('/')
+})
+```
+
+## Handling HTTPExceptions
+
+You can handle uncaught HTTPExceptions with [`app.onError`](/docs/api/hono#error-handling). They include a `getResponse` method that returns a new `Response`, created from the error `status`, and either the error `message`, or the [custom response](#custom-response) set when the error was thrown.
 
 ```ts twoslash
 import { Hono } from 'hono'
@@ -51,35 +66,19 @@ import { HTTPException } from 'hono/http-exception'
 
 // ...
 
-app.onError((err, c) => {
-  if (err instanceof HTTPException) {
+app.onError((error, c) => {
+  if (error instanceof HTTPException) {
+    console.error(error.cause)
     // Get the custom response
-    return err.getResponse()
+    return error.getResponse()
   }
   // ...
   // ---cut-start---
-  return c.text('Error')
+  return c.text('Unexpected error')
   // ---cut-end---
 })
 ```
 
-## `cause`
-
-The `cause` option is available to add a [`cause`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) data.
-
-```ts twoslash
-import { Hono, Context } from 'hono'
-import { HTTPException } from 'hono/http-exception'
-const app = new Hono()
-declare const message: string
-declare const authorize: (c: Context) => void
-// ---cut---
-app.post('/auth', async (c, next) => {
-  try {
-    authorize(c)
-  } catch (e) {
-    throw new HTTPException(401, { message, cause: e })
-  }
-  await next()
-})
-```
+::: warning
+**`HTTPException.getResponse` does not include headers**. To include headers already set in `Context`, you must apply them to a new `Response`.
+:::

--- a/docs/api/exception.md
+++ b/docs/api/exception.md
@@ -56,7 +56,7 @@ app.post('/login', async (c) => {
 
 ## Handling HTTPExceptions
 
-You can handle uncaught HTTPExceptions with [`app.onError`](/docs/api/hono#error-handling). They include a `getResponse` method that returns a new `Response`, created from the error `status`, and either the error `message`, or the [custom response](#custom-response) set when the error was thrown.
+You can handle uncaught HTTPExceptions with [`app.onError`](/docs/api/hono#error-handling). They include a `getResponse` method that returns a new `Response` created from the error `status`, and either the error `message`, or the [custom response](#custom-response) set when the error was thrown.
 
 ```ts twoslash
 import { Hono } from 'hono'

--- a/docs/api/exception.md
+++ b/docs/api/exception.md
@@ -80,5 +80,5 @@ app.onError((error, c) => {
 ```
 
 ::: warning
-**`HTTPException.getResponse` does not include headers**. To include headers already set in `Context`, you must apply them to a new `Response`.
+**`HTTPException.getResponse` is not aware of `Context`**. To include headers already set in `Context`, you must apply them to a new `Response`.
 :::

--- a/docs/api/exception.md
+++ b/docs/api/exception.md
@@ -1,6 +1,6 @@
 # HTTPException
 
-When a fatal error occurs, Hono (and many ecosystem middleware) will throw an `HTTPException`. This is a custom Hono `Error` that simplifies [returning error responses](#handling-httpexceptions).
+When a fatal error occurs, Hono (and many ecosystem middleware) may throw an `HTTPException`. This is a custom Hono `Error` that simplifies [returning error responses](#handling-httpexceptions).
 
 ## Throwing HTTPExceptions
 

--- a/docs/api/hono.md
+++ b/docs/api/hono.md
@@ -44,9 +44,13 @@ app.notFound((c) => {
 })
 ```
 
+:::warning
+The `notFound` method is only called from the top-level app. For more information, see this [issue](https://github.com/honojs/hono/issues/3465#issuecomment-2381210165).
+:::
+
 ## Error Handling
 
-`app.onError` handles an error and returns a customized Response.
+`app.onError` allows you to handle uncaught errors and return a custom Response.
 
 ```ts twoslash
 import { Hono } from 'hono'
@@ -57,6 +61,10 @@ app.onError((err, c) => {
   return c.text('Custom Error Message', 500)
 })
 ```
+
+::: info
+If both a parent app and its routes have `onError` handlers, the route-level handlers get priority.
+:::
 
 ## fire()
 


### PR DESCRIPTION
### Motivations
Questions have come in on the Discord server from users who interpreted the docs to mean that `HTTPException` *must* be used. There are also some implementation details and "gotchas" that the docs didn't cover.

### What's Changed
- clarify that `HTTPException` is thrown by Hono ecosystem code, but that devs can throw it themselves
- specify why `HTTPException` might be used instead of other errors
- add context about response types and header behavior
- add call-out about custom response status
- add info about `onError` and `notFound` behavior in sub-routes