### PR TITLE
Clarify how validator() from hono-openapi automatically adds request schema to OpenAPI docs

### DIFF
--- a/examples/hono-openapi.md
+++ b/examples/hono-openapi.md
@@ -61,6 +61,10 @@ app.get(
 )
 ```
 
+> **Note:**  
+> When using `validator()` from `hono-openapi`, any validation added for `query`, `json`, `param` or `form` is automatically included in the OpenAPI request schema.  
+> There’s no need to manually define request parameters inside `describeRoute()`.
+
 ---
 
 ### 3. Generate OpenAPI Spec


### PR DESCRIPTION
This PR adds a short note to the `hono-openapi` docs explaining that when using `validator()` for `query`, `json`, or `form`, the corresponding validation schema is automatically included in the OpenAPI request section.

This helps clarify that developers don’t need to manually define request parameters inside `describeRoute()`.

Fixes #750