### PR TITLE
Update usage of Service Binding for RPC

### DIFF
--- a/docs/guides/rpc.md
+++ b/docs/guides/rpc.md
@@ -437,7 +437,7 @@ services = [
 
 ```ts
 // src/client.ts
-const client = hc<CreateProfileType>('https://valid-url.com', {
+const client = hc<CreateProfileType>('http://localhost', {
   fetch: c.env.AUTH.fetch.bind(c.env.AUTH),
 })
 ```


### PR DESCRIPTION
Example showing with `/` does not work since it generates an invalid url.

With a random https://{ANY_VALID_DOMAIN}, it will work as expected