### PR TITLE
Add hono-zod-openapi to 3rd party middlewares list

### DIFF
--- a/docs/middleware/third-party.md
+++ b/docs/middleware/third-party.md
@@ -30,6 +30,7 @@ Most of this middleware leverages external libraries.
 - [Scalar](https://github.com/scalar/scalar/tree/main/integrations/hono)
 - [Swagger UI](https://github.com/honojs/middleware/tree/main/packages/swagger-ui)
 - [Hono OpenAPI](https://github.com/rhinobase/hono-openapi)
+- [hono-zod-openapi](https://github.com/paolostyle/hono-zod-openapi)
 
 ### Others
 


### PR DESCRIPTION
I'd like to add my middleware [hono-zod-openapi](https://github.com/paolostyle/hono-zod-openapi) to the list of 3rd party middlewares. It's a bit more conveniant to use compared to the competitors as often it just works by passing a zod schema to the middleware as opposed to writing most of the OpenAPI schema, but it's very flexible. Example:

```
import { Hono } from 'hono';
import * as z from 'zod';
import { createOpenApiDocument, openApi } from 'hono-zod-openapi';

export const app = new Hono().get(
  '/user',
  openApi({
    tags: ['User'],
    responses: {
      200: z.object({ hi: z.string() }).meta({ example: { hi: 'user' } }),
    },
    request: {
      query: z.object({ id: z.string() }),
    },
  }),
  (c) => {
    // works identically to @hono/zod-validator
    const { id } = c.req.valid('query');
    return c.json({ hi: id }, 200);
  },
);

// this will add a `GET /doc` route to the `app` router
createOpenApiDocument(app, {
  info: {
    title: 'Example API',
    version: '1.0.0',
  },
});
```

I recently release v1 of the library with zod v4 support, so I think it's a good moment to try to make it more popular.