### PR TITLE
docs(bun): bun.sh -> bun.com

### DIFF
--- a/docs/getting-started/bun.md
+++ b/docs/getting-started/bun.md
@@ -1,11 +1,11 @@
 # Bun
 
-[Bun](https://bun.sh) is another JavaScript runtime. It's not Node.js or Deno. Bun includes a trans compiler, we can write the code with TypeScript.
+[Bun](https://bun.com) is another JavaScript runtime. It's not Node.js or Deno. Bun includes a trans compiler, we can write the code with TypeScript.
 Hono also works on Bun.
 
 ## 1. Install Bun
 
-To install `bun` command, follow the instruction in [the official web site](https://bun.sh).
+To install `bun` command, follow the instruction in [the official web site](https://bun.com).
 
 ## 2. Setup
 

--- a/docs/getting-started/google-cloud-run.md
+++ b/docs/getting-started/google-cloud-run.md
@@ -130,5 +130,5 @@ If you want to deploy using Deno or Bun runtimes (or a customised Nodejs contain
 For information on containerizing please refer to:
 
 - [Nodejs](/docs/getting-started/nodejs#building-deployment)
-- [Bun](https://bun.sh/guides/ecosystem/docker)
+- [Bun](https://bun.com/guides/ecosystem/docker)
 - [Deno](https://docs.deno.com/examples/google_cloud_run_tutorial)

--- a/docs/helpers/adapter.md
+++ b/docs/helpers/adapter.md
@@ -33,7 +33,7 @@ Supported Runtimes, Serverless Platforms and Cloud Services:
   - [`Deno.env`](https://docs.deno.com/runtime/manual/basics/env_variables)
   - `.env` file
 - Bun
-  - [`Bun.env`](https://bun.sh/guides/runtime/set-env)
+  - [`Bun.env`](https://bun.com/guides/runtime/set-env)
   - `process.env`
 - Node.js
   - `process.env`


### PR DESCRIPTION
It seems that Bun's official domain is now `bun.com`.
