### PR TITLE
docs(validation): add Standard Schema validator middleware section

### DIFF
--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -274,3 +274,161 @@ const route = app.post(
   }
 )
 ```
+
+## Standard Schema Validator Middleware
+
+[Standard Schema](https://standardschema.dev/) is a specification that provides a common interface for TypeScript validation libraries. It was created by the maintainers of Zod, Valibot, and ArkType to allow ecosystem tools to work with any validation library without needing custom adapters.
+
+The [Standard Schema Validator Middleware](https://github.com/honojs/middleware/tree/main/packages/standard-validator) lets you use any Standard Schema-compatible validation library with Hono, giving you the flexibility to choose your preferred validator while maintaining consistent type safety.
+
+::: code-group
+
+```sh [npm]
+npm i @hono/standard-validator
+```
+
+```sh [yarn]
+yarn add @hono/standard-validator
+```
+
+```sh [pnpm]
+pnpm add @hono/standard-validator
+```
+
+```sh [bun]
+bun add @hono/standard-validator
+```
+
+:::
+
+Import `sValidator` from the package:
+
+```ts
+import { sValidator } from '@hono/standard-validator'
+```
+
+### With Zod
+
+You can use Zod with the Standard Schema validator:
+
+::: code-group
+
+```sh [npm]
+npm i zod
+```
+
+```sh [yarn]
+yarn add zod
+```
+
+```sh [pnpm]
+pnpm add zod
+```
+
+```sh [bun]
+bun add zod
+```
+
+:::
+
+```ts
+import { z } from 'zod'
+import { sValidator } from '@hono/standard-validator'
+
+const schema = z.object({
+  name: z.string(),
+  age: z.number(),
+})
+
+app.post('/author', sValidator('json', schema), (c) => {
+  const data = c.req.valid('json')
+  return c.json({
+    success: true,
+    message: `${data.name} is ${data.age}`,
+  })
+})
+```
+
+### With Valibot
+
+[Valibot](https://valibot.dev/) is a lightweight alternative to Zod with a modular design:
+
+::: code-group
+
+```sh [npm]
+npm i valibot
+```
+
+```sh [yarn]
+yarn add valibot
+```
+
+```sh [pnpm]
+pnpm add valibot
+```
+
+```sh [bun]
+bun add valibot
+```
+
+:::
+
+```ts
+import * as v from 'valibot'
+import { sValidator } from '@hono/standard-validator'
+
+const schema = v.object({
+  name: v.string(),
+  age: v.number(),
+})
+
+app.post('/author', sValidator('json', schema), (c) => {
+  const data = c.req.valid('json')
+  return c.json({
+    success: true,
+    message: `${data.name} is ${data.age}`,
+  })
+})
+```
+
+### With ArkType
+
+[ArkType](https://arktype.io/) offers TypeScript-native syntax for runtime validation:
+
+::: code-group
+
+```sh [npm]
+npm i arktype
+```
+
+```sh [yarn]
+yarn add arktype
+```
+
+```sh [pnpm]
+pnpm add arktype
+```
+
+```sh [bun]
+bun add arktype
+```
+
+:::
+
+```ts
+import { type } from 'arktype'
+import { sValidator } from '@hono/standard-validator'
+
+const schema = type({
+  name: 'string',
+  age: 'number',
+})
+
+app.post('/author', sValidator('json', schema), (c) => {
+  const data = c.req.valid('json')
+  return c.json({
+    success: true,
+    message: `${data.name} is ${data.age}`,
+  })
+})
+```


### PR DESCRIPTION
This adds comprehensive documentation for the Standard Schema validator middleware to the validation guide.

Standard Schema is a specification created by the maintainers of Zod, Valibot, and ArkType that provides a common interface for TypeScript validation libraries. The Standard Schema validator middleware (`@hono/standard-validator`) was recently merged in PR #887 and allows developers to use any Standard Schema-compatible validation library with Hono.

The new section includes installation instructions, three complete examples (Zod, Valibot, and ArkType), and explains the benefits of using Standard Schema for validation in Hono applications. All examples use consistent schema patterns to make it easy to compare the different validation libraries.

This addresses the need for up-to-date documentation on modern validation approaches available in Hono.