### PR TITLE
Docs: fixed typos

### DIFF
--- a/docs/api/hono.md
+++ b/docs/api/hono.md
@@ -199,7 +199,7 @@ const app = new Hono({ strict: false })
 
 ## router option
 
-The `router` option specifices which router to use. The default router is `SmartRouter`. If you want to use `RegExpRouter`, pass it to a new `Hono` instance:
+The `router` option specifies which router to use. The default router is `SmartRouter`. If you want to use `RegExpRouter`, pass it to a new `Hono` instance:
 
 ```ts twoslash
 import { Hono } from 'hono'

--- a/docs/guides/jsx.md
+++ b/docs/guides/jsx.md
@@ -40,7 +40,7 @@ For Deno, you have to modify the `deno.json` instead of the `tsconfig.json`:
 ## Usage
 
 :::info
-If you are comming straight from the [Quick Start](/docs/#quick-start), the main file has a `.ts` extension - you need to change it to `.tsx` - otherwise you will not be able to run the application at all. You should additionally modify the `package.json` (or `deno.json` if you are using Deno) to reflect that change (e.g. instead of having `bun run --hot src/index.ts` in dev script, you should have `bun run --hot src/index.tsx`).
+If you are coming straight from the [Quick Start](/docs/#quick-start), the main file has a `.ts` extension - you need to change it to `.tsx` - otherwise you will not be able to run the application at all. You should additionally modify the `package.json` (or `deno.json` if you are using Deno) to reflect that change (e.g. instead of having `bun run --hot src/index.ts` in dev script, you should have `bun run --hot src/index.tsx`).
 :::
 
 `index.tsx`:

--- a/docs/middleware/builtin/bearer-auth.md
+++ b/docs/middleware/builtin/bearer-auth.md
@@ -19,7 +19,7 @@ import { bearerAuth } from 'hono/bearer-auth'
 ## Usage
 
 > [!NOTE]
-> Your `token` must match the regex `/[A-Za-z0-9._~+/-]+=*/`, otherwise a 400 error will be returned. Notably, this regex acommodates both URL-safe Base64- and standard Base64-encoded JWTs. This middleware does not require the bearer token to be a JWT, just that it matches the above regex.
+> Your `token` must match the regex `/[A-Za-z0-9._~+/-]+=*/`, otherwise a 400 error will be returned. Notably, this regex accommodates both URL-safe Base64- and standard Base64-encoded JWTs. This middleware does not require the bearer token to be a JWT, just that it matches the above regex.
 
 ```ts
 const app = new Hono()


### PR DESCRIPTION
Fixed three typos found in docs:

- specifices > specifies (docs/api/hono.md)
- comming > coming (docs/guides/jsx.md)
- acommodates > accommodates (docs/middleware/builtin/bearer-auth.md)

