### PR TITLE
docs(deno-get-started): move project name at end of command

### DIFF
--- a/docs/getting-started/deno.md
+++ b/docs/getting-started/deno.md
@@ -16,7 +16,7 @@ A starter for Deno is available.
 Start your project with the [`deno init`](https://docs.deno.com/runtime/reference/cli/init/) command.
 
 ```sh
-deno init --npm hono my-app --template=deno
+deno init --npm hono --template=deno my-app
 ```
 
 Move into `my-app`. For Deno, you don't have to install Hono explicitly.


### PR DESCRIPTION
Super minor change - placing the project name at the end of the command makes it easier to change it