### PR TITLE
add jsonv-ts to third-party middleware list

### DIFF
--- a/docs/middleware/third-party.md
+++ b/docs/middleware/third-party.md
@@ -53,3 +53,4 @@ Most of this middleware leverages external libraries.
 - [Highlight.io](https://www.highlight.io/docs/getting-started/backend-sdk/js/hono)
 - [Apitally (API monitoring & analytics)](https://docs.apitally.io/frameworks/hono)
 - [Cap Checkpoint](https://capjs.js.org/guide/middleware/hono.html)
+- [jsonv-ts (Validator, OpenAPI, MCP)](https://github.com/dswbx/jsonv-ts)


### PR DESCRIPTION
Please add [jsonv-ts](https://github.com/dswbx/jsonv-ts) to third-party middlewares. I've added it to the "Others" section, since it can be used as validator, for OpenAPI generation and has a fully independent web-spec compliant MCP implementation that also allows tools from hono routes. 