### PR TITLE
Revise Cloudflare Workers deployment guide

### DIFF
--- a/docs/getting-started/cloudflare-workers.md
+++ b/docs/getting-started/cloudflare-workers.md
@@ -303,8 +303,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22" # use your node version!
-          cache: "pnpm" # use your package manager!
+          node-version: '22' # use your node version!
+          cache: 'pnpm' # use your package manager!
       - name: Install dependencies
         run: pnpm install --frozen-lockfile # use your package manager!
       - name: Deploy


### PR DESCRIPTION
Updated instructions for setting up Cloudflare Workers deployment with GitHub Actions, including token management and workflow configuration.

The old workflow example was very likely going to fail because of missing nodejs and package manager setup - also if you didn't set your `account_id` in the `wrangler.jsonc/toml`.