### PR TITLE
docs: Update bun.md with 'dev' command instructions

### DIFF
--- a/docs/getting-started/bun.md
+++ b/docs/getting-started/bun.md
@@ -39,7 +39,7 @@ Then add the `dev` command to your existing `package.json`.
 {
   "scripts": {
     "dev": "bun run --hot src/index.ts"
-  },
+  }
 }
 ```
 


### PR DESCRIPTION
Added instructions for adding the 'dev' command to package.json and clarified the location of the 'Hello World' script.

I found this helpful for setting up Hono on existing Bun projects, as I have first created a Bun project from [Bun's quickstart guide](https://bun.com/docs/quickstart) using `bun init`.

Adding the link to [Hono's Bun starter template](https://github.com/honojs/starter/tree/main/templates/bun) in the docs should also be useful for other developers to see a minimal example and adjust according to their existing project setup, as it took me a while to find the repo without running `bun create hono`.