### PR TITLE
Update installation command for Google Cloud SDK

### DIFF
--- a/docs/getting-started/google-cloud-run.md
+++ b/docs/getting-started/google-cloud-run.md
@@ -13,7 +13,7 @@ When working with Google Cloud Platform it is easiest to work with the [gcloud C
 For example, on MacOS using Homebrew:
 
 ```sh
-brew install --cask google-cloud-sdk
+brew install --cask gcloud-cli
 ```
 
 Authenticate with the CLI.


### PR DESCRIPTION
Homebrew updated gcloud name from `google-cloud-sdk` to `gcloud-cli`: https://formulae.brew.sh/cask/gcloud-cli