### PR TITLE
bun now support `CompressionStream`

### DIFF
--- a/docs/middleware/builtin/compress.md
+++ b/docs/middleware/builtin/compress.md
@@ -4,8 +4,6 @@ This middleware compresses the response body, according to `Accept-Encoding` req
 
 ::: info
 **Note**: On Cloudflare Workers and Deno Deploy, the response body will be compressed automatically, so there is no need to use this middleware.
-
-**Bun**: This middleware uses `CompressionStream` which is not yet supported in bun.
 :::
 
 ## Import


### PR DESCRIPTION
bun now support `CompressionStream`, the warning for Compress Middleware has been removed.
This is release note→https://bun.sh/blog/bun-v1.3.3#compressionstream-and-decompressionstream