### PR TITLE
add Client Components example link

### DIFF
--- a/docs/guides/jsx-dom.md
+++ b/docs/guides/jsx-dom.md
@@ -46,6 +46,8 @@ You can use `render()` to insert JSX components within a specified HTML element.
 render(<Component />, container)
 ```
 
+You can see full example code here: [Counter example](https://github.com/honojs/examples/tree/main/hono-vite-jsx).
+
 ## Hooks compatible with React
 
 hono/jsx/dom has Hooks that are compatible or partially compatible with React. You can learn about these APIs by looking at [the React documentation](https://react.dev/reference/react/hooks).


### PR DESCRIPTION
This pull request introduces a direct link to the example of using the client component.
[#3270](https://github.com/honojs/hono/issues/3270)
[4547](https://github.com/orgs/honojs/discussions/4547)
[2596](https://github.com/orgs/honojs/discussions/2596)