### PR TITLE
docs(middleware): add LogTape to third-party middleware list

### DIFF
--- a/docs/middleware/third-party.md
+++ b/docs/middleware/third-party.md
@@ -47,6 +47,7 @@ Most of this middleware leverages external libraries.
 
 - [Apitally (API monitoring & analytics)](https://docs.apitally.io/frameworks/hono)
 - [Highlight.io](https://www.highlight.io/docs/getting-started/backend-sdk/js/hono)
+- [LogTape (Logging)](https://logtape.org/manual/integrations#hono)
 - [OpenTelemetry](https://github.com/honojs/middleware/tree/main/packages/otel)
 - [Prometheus Metrics](https://github.com/honojs/middleware/tree/main/packages/prometheus)
 - [Sentry](https://github.com/honojs/middleware/tree/main/packages/sentry)


### PR DESCRIPTION
`@logtape/hono` is a structured logging middleware for Hono. For details, see also <https://github.com/orgs/honojs/discussions/4614>!