### PR TITLE
Add allowedAlgorithms to verifyWithJwks options

### DIFF
--- a/docs/middleware/builtin/jwk.md
+++ b/docs/middleware/builtin/jwk.md
@@ -80,7 +80,7 @@ const id_payload = await verifyWithJwks(
   id_token,
   {
     jwks_uri: 'https://your-auth-server/.well-known/jwks.json',
-    allowedAlgorithms: ["RS256"],
+    allowedAlgorithms: ['RS256'],
   },
   {
     cf: { cacheEverything: true, cacheTtl: 3600 },


### PR DESCRIPTION
allowedAlgorithms is required and was introduced in https://github.com/honojs/hono/commit/190f6e28e2ca85ce3d1f2f54db1310f5f3eab134 and published in the patch update 4.11.4