### PR TITLE
docs(jsx): add info about metadata hoisting behavior

### DIFF
--- a/docs/guides/jsx.md
+++ b/docs/guides/jsx.md
@@ -116,6 +116,10 @@ app.get('/about', (c) => {
 export default app
 ```
 
+:::info
+When hoisting occurs, existing elements are not removed. Elements appearing later are added to the end. For example, if you have `<title>Default</title>` in your `<head>` and a component renders `<title>Page Title</title>`, both titles will appear in the head.
+:::
+
 ## Fragment
 
 Use Fragment to group multiple elements without adding extra nodes:


### PR DESCRIPTION
Clarify that when hoisting occurs, existing elements are not removed and elements appearing later are added to the end. 

I want to prevent issues from being raised by explicitly stating that this is by design.

fixes https://github.com/honojs/hono/issues/4648