### PR TITLE
fix:alg is now required in jwt middleware

### DIFF
--- a/docs/middleware/builtin/jwt.md
+++ b/docs/middleware/builtin/jwt.md
@@ -29,6 +29,7 @@ app.use(
   '/auth/*',
   jwt({
     secret: 'it-is-very-secret',
+    alg: 'HS256',
   })
 )
 
@@ -46,6 +47,7 @@ app.use(
   '/auth/*',
   jwt({
     secret: 'it-is-very-secret',
+    alg: 'HS256',
     issuer: 'my-trusted-issuer',
   })
 )
@@ -64,6 +66,7 @@ app.get('/auth/page', (c) => {
 app.use('/auth/*', (c, next) => {
   const jwtMiddleware = jwt({
     secret: c.env.JWT_SECRET,
+    alg: 'HS256',
   })
   return jwtMiddleware(c, next)
 })
@@ -77,15 +80,15 @@ app.use('/auth/*', (c, next) => {
 
 A value of your secret key.
 
+### <Badge type="danger" text="required" /> alg: `string`
+
+An algorithm type that is used for verifying.
+
+Available types are `HS256` | `HS384` | `HS512` | `RS256` | `RS384` | `RS512` | `PS256` | `PS384` | `PS512` | `ES256` | `ES384` | `ES512` | `EdDSA`.
+
 ### <Badge type="info" text="optional" /> cookie: `string`
 
 If this value is set, then the value is retrieved from the cookie header using that value as a key, which is then validated as a token.
-
-### <Badge type="info" text="optional" /> alg: `string`
-
-An algorithm type that is used for verifying. The default is `HS256`.
-
-Available types are `HS256` | `HS384` | `HS512` | `RS256` | `RS384` | `RS512` | `PS256` | `PS384` | `PS512` | `ES256` | `ES384` | `ES512` | `EdDSA`.
 
 ### <Badge type="info" text="optional" /> headerName: `string`
 
@@ -96,6 +99,7 @@ app.use(
   '/auth/*',
   jwt({
     secret: 'it-is-very-secret',
+    alg: 'HS256',
     headerName: 'x-custom-auth-header',
   })
 )


### PR DESCRIPTION
## What does this PR do?
- Change the 'alg' parameter of 'middleware/jwt' from optional to required, and modify the related examples.
- I saw in the document that the 'alg' of the verify method has been modified. So I just fix 'middleware/jwt'

## Related Issue
- Closes #800  
