### PR TITLE
docs: use correct relative imports in code examples

### DIFF
--- a/docs/concepts/stacks.md
+++ b/docs/concepts/stacks.md
@@ -100,7 +100,7 @@ Then, magically, completion works and the endpoint path and request type are sug
 ![](/images/sc03.gif)
 
 ```ts
-import { AppType } from './server'
+import type { AppType } from './server.js'
 import { hc } from 'hono/client'
 
 const client = hc<AppType>('/api')
@@ -177,7 +177,7 @@ import {
   QueryClient,
   QueryClientProvider,
 } from '@tanstack/react-query'
-import { AppType } from '../functions/api/[[route]]'
+import type { AppType } from '../functions/api/[[route]]'
 import { hc, InferResponseType, InferRequestType } from 'hono/client'
 
 const queryClient = new QueryClient()

--- a/docs/getting-started/azure-functions.md
+++ b/docs/getting-started/azure-functions.md
@@ -85,7 +85,7 @@ Create `src/functions/httpTrigger.ts`:
 // src/functions/httpTrigger.ts
 import { app } from '@azure/functions'
 import { azureHonoHandler } from '@marplex/hono-azurefunc-adapter'
-import honoApp from '../app'
+import honoApp from '../app.js'
 
 app.http('httpTrigger', {
   methods: [

--- a/docs/getting-started/cloudflare-pages.md
+++ b/docs/getting-started/cloudflare-pages.md
@@ -83,7 +83,7 @@ Edit `src/index.tsx` like the following:
 
 ```tsx
 import { Hono } from 'hono'
-import { renderer } from './renderer'
+import { renderer } from './renderer.js'
 
 const app = new Hono()
 

--- a/docs/getting-started/lambda-edge.md
+++ b/docs/getting-started/lambda-edge.md
@@ -71,7 +71,7 @@ Edit `bin/my-app.ts`.
 #!/usr/bin/env node
 import 'source-map-support/register'
 import * as cdk from 'aws-cdk-lib'
-import { MyAppStack } from '../lib/my-app-stack'
+import { MyAppStack } from '../lib/my-app-stack.js'
 
 const app = new cdk.App()
 new MyAppStack(app, 'MyAppStack', {

--- a/docs/guides/best-practices.md
+++ b/docs/guides/best-practices.md
@@ -100,8 +100,8 @@ Then, import them and mount on the paths `/authors` and `/books` with `app.route
 ```ts
 // index.ts
 import { Hono } from 'hono'
-import authors from './authors'
-import books from './books'
+import authors from './authors.js'
+import books from './books.js'
 
 const app = new Hono()
 
@@ -133,7 +133,7 @@ export type AppType = typeof app
 If you pass the type of the `app` to `hc`, it will get the correct type.
 
 ```ts
-import type { AppType } from './authors'
+import type { AppType } from './authors.js'
 import { hc } from 'hono/client'
 
 // 😃

--- a/docs/guides/rpc.md
+++ b/docs/guides/rpc.md
@@ -728,8 +728,8 @@ You can then import the sub-routers as you usually would, and make sure you chai
 ```ts
 // index.ts
 import { Hono } from 'hono'
-import authors from './authors'
-import books from './books'
+import authors from './authors.js'
+import books from './books.js'
 
 const app = new Hono()
 
@@ -789,7 +789,7 @@ Like in the case of [Hono version mismatch](#hono-version-mismatch), you'll run 
 Compiling your client including the server app gives you the best performance. Put the following code in your project:
 
 ```ts
-import { app } from './app'
+import { app } from './app.js'
 import { hc } from 'hono/client'
 
 // this is a trick to calculate the type when compiling
@@ -833,13 +833,13 @@ As described in [Using RPC with larger applications](#using-rpc-with-larger-appl
 
 ```ts
 // authors-cli.ts
-import { app as authorsApp } from './authors'
+import { app as authorsApp } from './authors.js'
 import { hc } from 'hono/client'
 
 const authorsClient = hc<typeof authorsApp>('/authors')
 
 // books-cli.ts
-import { app as booksApp } from './books'
+import { app as booksApp } from './books.js'
 import { hc } from 'hono/client'
 
 const booksClient = hc<typeof booksApp>('/books')

--- a/docs/helpers/factory.md
+++ b/docs/helpers/factory.md
@@ -164,7 +164,7 @@ export default createFactory<Env>({
 
 ```ts
 // crud.ts
-import factoryWithDB from './factory-with-db'
+import factoryWithDB from './factory-with-db.js'
 
 const app = factoryWithDB.createApp()
 

--- a/docs/helpers/ssg.md
+++ b/docs/helpers/ssg.md
@@ -43,7 +43,7 @@ For Node.js, create a build script like this:
 
 ```ts
 // build.ts
-import app from './index'
+import app from './index.js'
 import { toSSG } from 'hono/ssg'
 import fs from 'fs/promises'
 
@@ -391,9 +391,9 @@ ${urls.map((url) => `<url><loc>${url}</loc></url>`).join('\n')}
 Applying plugins:
 
 ```ts
-import app from './index'
+import app from './index.js'
 import { toSSG } from 'hono/ssg'
-import { sitemapPlugin } from './plugins'
+import { sitemapPlugin } from './plugins.js'
 
 toSSG(app, fs, {
   plugins: [

--- a/docs/helpers/testing.md
+++ b/docs/helpers/testing.md
@@ -38,7 +38,7 @@ export default app
 import { Hono } from 'hono'
 import { testClient } from 'hono/testing'
 import { describe, it, expect } from 'vitest' // Or your preferred test runner
-import app from './app'
+import app from './app.js'
 
 describe('Search Endpoint', () => {
   // Create the test client from the app instance
@@ -69,7 +69,7 @@ To include headers in your test, pass them as the second parameter in the call. 
 import { Hono } from 'hono'
 import { testClient } from 'hono/testing'
 import { describe, it, expect } from 'vitest' // Or your preferred test runner
-import app from './app'
+import app from './app.js'
 
 describe('Search Endpoint', () => {
   // Create the test client from the app instance

--- a/docs/helpers/websocket.md
+++ b/docs/helpers/websocket.md
@@ -119,7 +119,7 @@ export default app
 ```ts
 // client.ts
 import { hc } from 'hono/client'
-import type app from './server'
+import type app from './server.js'
 
 const client = hc<typeof app>('http://localhost:8787')
 const ws = client.ws.$ws(0)

--- a/docs/middleware/builtin/basic-auth.md
+++ b/docs/middleware/builtin/basic-auth.md
@@ -150,7 +150,7 @@ app.use(
 Or less hardcoded:
 
 ```ts
-import { users } from '../config/users'
+import { users } from '../config/users.js'
 
 app.use(
   '/auth/*',


### PR DESCRIPTION
Per #579, docs/ code examples use relative imports without file extensions and import types without the `type` keyword, which fails on a fresh Hono app whose default `tsconfig.json` uses NodeNext module resolution and `verbatimModuleSyntax`.

Two classes of fixes:

1. Extensionless relative imports get `.js` added (`./foo` → `./foo.js`). Without this, NodeNext throws:
   ```
   Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'.
   ```

2. Value-position `AppType` imports in `docs/concepts/stacks.md` are converted to `import type`. Without this, `verbatimModuleSyntax` throws:
   ```
   'AppType' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.
   ```

The two `'../functions/api/[[route]]'` imports are intentionally left as-is — those are Cloudflare Pages route patterns, not real file paths.

Closes #579