### PR TITLE
docs(nextjs): use `getRequestListener` instead of vercel helper

### DIFF
--- a/docs/getting-started/nextjs.md
+++ b/docs/getting-started/nextjs.md
@@ -135,11 +135,11 @@ bun add @hono/node-server
 
 :::
 
-Then, you can utilize the `handle` function imported from `@hono/node-server/vercel` in `pages/api/[[...route]].ts`.
+Then, you can utilize the `getRequestListener` function imported from `@hono/node-server` in `pages/api/[[...route]].ts`.
 
 ```ts
+import { getRequestListener } from '@hono/node-server'
 import { Hono } from 'hono'
-import { handle } from '@hono/node-server/vercel'
 import type { PageConfig } from 'next'
 
 export const config: PageConfig = {
@@ -156,7 +156,7 @@ app.get('/hello', (c) => {
   })
 })
 
-export default handle(app)
+export default getRequestListener(app.fetch)
 ```
 
 In order for this to work with the Pages Router, it's important to disable Vercel Node.js helpers by setting up an environment variable in your project dashboard or in your `.env` file.


### PR DESCRIPTION
Since `@hono/node-server/vercel` was removed in v2, we've switched to using `getRequestListener` as an alternative.
https://github.com/honojs/node-server/releases/tag/v2.0.0