### PR TITLE
docs(stacks): use type-only import for AppType

### DIFF
--- a/docs/concepts/stacks.md
+++ b/docs/concepts/stacks.md
@@ -100,7 +100,7 @@ Then, magically, completion works and the endpoint path and request type are sug
 ![](/images/sc03.gif)
 
 ```ts
-import { AppType } from './server'
+import type { AppType } from './server'
 import { hc } from 'hono/client'
 
 const client = hc<AppType>('/api')
@@ -177,7 +177,7 @@ import {
   QueryClient,
   QueryClientProvider,
 } from '@tanstack/react-query'
-import { AppType } from '../functions/api/[[route]]'
+import type { AppType } from '../functions/api/[[route]]'
 import { hc, InferResponseType, InferRequestType } from 'hono/client'
 
 const queryClient = new QueryClient()


### PR DESCRIPTION
Same as #622 and #744, applied to docs/concepts/stacks.md.

Both `AppType` imports in this page are only used as a type parameter to `hc<>()`, so they should be type-only imports. With `verbatimModuleSyntax: true`, the current example fails to compile with `TS1484`.

<details>
<summary>Reproduction</summary>

Node.js v22.12.0, TypeScript 6.0.3, Hono 4.12.18.

`tsconfig.json`

```json
{
  "compilerOptions": {
    "target": "ESNext",
    "module": "ESNext",
    "moduleResolution": "Bundler",
    "strict": true,
    "verbatimModuleSyntax": true,
    "skipLibCheck": true,
    "noEmit": true
  }
}
```

`tsc --noEmit` on the current example in `docs/concepts/stacks.md`

```
client.ts:1:10 - error TS1484: 'AppType' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.

1 import { AppType } from './server'
           ~~~~~~~


Found 1 error in client.ts:1
```

<img width="1004" height="201" alt="image" src="https://github.com/user-attachments/assets/fbd9a594-74b6-4f0d-8923-4d5268c9ded3" />


After applying this PR, `tsc --noEmit` exits cleanly with no output.

</details>

Happy to adjust if anything is off.
