### PR TITLE
docs(websocket): document built-in node ws support

### DIFF
--- a/docs/getting-started/nodejs.md
+++ b/docs/getting-started/nodejs.md
@@ -135,6 +135,36 @@ serve({
 })
 ```
 
+## WebSocket
+
+WebSocket support is built into `@hono/node-server`. Install `ws` and, if you use TypeScript, `@types/ws`. Then create a `WebSocketServer` with `{ noServer: true }` and pass it to `serve()` with the `websocket` option.
+
+`@hono/node-ws` is deprecated.
+
+```ts
+import { serve, upgradeWebSocket } from '@hono/node-server'
+import { Hono } from 'hono'
+import { WebSocketServer } from 'ws'
+
+const app = new Hono()
+
+app.get(
+  '/ws',
+  upgradeWebSocket(() => ({
+    onMessage(event, ws) {
+      ws.send(event.data)
+    },
+  }))
+)
+
+const wss = new WebSocketServer({ noServer: true })
+
+serve({
+  fetch: app.fetch,
+  websocket: { server: wss },
+})
+```
+
 ## Access the raw Node.js APIs
 
 You can access the Node.js APIs from `c.env.incoming` and `c.env.outgoing`.

--- a/docs/helpers/websocket.md
+++ b/docs/helpers/websocket.md
@@ -1,7 +1,7 @@
 # WebSocket Helper
 
 WebSocket Helper is a helper for server-side WebSockets in Hono applications.
-Currently Cloudflare Workers / Pages, Deno, and Bun adapters are available.
+Currently Cloudflare Workers / Pages, Deno, Bun, and Node.js adapters are available.
 
 ## Import
 
@@ -29,9 +29,17 @@ export default {
 }
 ```
 
+```ts [Node.js]
+import { serve, upgradeWebSocket } from '@hono/node-server'
+import { Hono } from 'hono'
+import { WebSocketServer } from 'ws'
+```
+
 :::
 
-If you use Node.js, you can use [@hono/node-ws](https://github.com/honojs/middleware/tree/main/packages/node-ws).
+On Node.js, WebSocket support is built into `@hono/node-server`. To enable it, install `ws` and, if you use TypeScript, `@types/ws`. Then create a `WebSocketServer` with `{ noServer: true }` and pass it to `serve()` via the `websocket` option.
+
+`@hono/node-ws` is deprecated.
 
 ## `upgradeWebSocket()`
 
@@ -183,4 +191,30 @@ export default {
   fetch: app.fetch,
   websocket,
 }
+```
+
+### Node.js
+
+```ts
+import { serve, upgradeWebSocket } from '@hono/node-server'
+import { Hono } from 'hono'
+import { WebSocketServer } from 'ws'
+
+const app = new Hono()
+
+app.get(
+  '/ws',
+  upgradeWebSocket(() => ({
+    onMessage(event, ws) {
+      ws.send(event.data)
+    },
+  }))
+)
+
+const wss = new WebSocketServer({ noServer: true })
+
+serve({
+  fetch: app.fetch,
+  websocket: { server: wss },
+})
 ```

--- a/docs/middleware/third-party.md
+++ b/docs/middleware/third-party.md
@@ -56,7 +56,6 @@ Most of this middleware leverages external libraries.
 ### Server / Adapter
 
 - [GraphQL Server](https://github.com/honojs/middleware/tree/main/packages/graphql-server)
-- [Node WebSocket Helper](https://github.com/honojs/middleware/tree/main/packages/node-ws)
 - [tRPC Server](https://github.com/honojs/middleware/tree/main/packages/trpc-server)
 
 ### Transpiler


### PR DESCRIPTION
Update hono docs about built-in websocket support in nodejs adapter

related prs: https://github.com/honojs/node-server/pull/328 & https://github.com/honojs/middleware/pull/1862