### PR TITLE
docs(streaming): use !stream.aborted in SSE example

### DIFF
--- a/docs/helpers/streaming.md
+++ b/docs/helpers/streaming.md
@@ -70,7 +70,7 @@ let id = 0
 
 app.get('/sse', async (c) => {
   return streamSSE(c, async (stream) => {
-    while (true) {
+    while (!stream.aborted) {
       const message = `It is ${new Date().toISOString()}`
       await stream.writeSSE({
         data: message,


### PR DESCRIPTION
I think `while (!stream.aborted)` is better for the example since `while (true)` keeps the loop going even after the client is gone, leaking work on every disconnect.