### PR TITLE
docs(middleware): add InferDI to third-party middleware

### DIFF
--- a/docs/middleware/third-party.md
+++ b/docs/middleware/third-party.md
@@ -86,6 +86,7 @@ Most of this middleware leverages external libraries.
 - [Hono Rate Limiter](https://github.com/rhinobase/hono-rate-limiter)
 - [Hono Problem Details (RFC 9457)](https://github.com/paveg/hono-problem-details)
 - [Hono Simple DI](https://github.com/maou-shonen/hono-simple-DI)
+- [InferDI](https://github.com/inferdi/inferdi/tree/main/packages/hono)
 - [Idempotency (Stripe-style idempotency keys)](https://github.com/paveg/hono-idempotency)
 - [idempot-js](https://js.idempot.dev) - spec-compliant middleware, supporting multiple storage backends (redis, postgres, mysql, sqlite)
 - [jsonv-ts (Validator, OpenAPI, MCP)](https://github.com/dswbx/jsonv-ts)


### PR DESCRIPTION
### PR Description

**Summary:**
This pull request updates the third-party middleware documentation by adding InferDI to the list.

**Changes:**
- **docs/middleware/third-party.md**: Added a new entry for InferDI with a link to its Hono adapter repository ([https://github.com/inferdi/inferdi/tree/main/packages/hono](https://github.com/inferdi/inferdi/tree/main/packages/hono)).

**What it is:**
[InferDI](https://github.com/inferdi/inferdi/tree/main/packages/hono) provides type-safe dependency injection for Hono with request scopes, explicit disposal, and no decorators.