### PR TITLE
docs(middleware): add oRPC to third-party middleware

### DIFF
--- a/docs/middleware/third-party.md
+++ b/docs/middleware/third-party.md
@@ -56,6 +56,7 @@ Most of this middleware leverages external libraries.
 ### Server / Adapter
 
 - [GraphQL Server](https://github.com/honojs/middleware/tree/main/packages/graphql-server)
+- [oRPC](https://orpc.dev/docs/adapters/hono)
 - [tRPC Server](https://github.com/honojs/middleware/tree/main/packages/trpc-server)
 
 ### Transpiler


### PR DESCRIPTION
Adds [oRPC](https://orpc.dev/docs/adapters/hono) to the **Server / Adapter** list. oRPC ships an official Hono adapter.

Closes #774.