### PR TITLE
docs(bun): mention Bun can also run plain JavaScript

### DIFF
--- a/docs/getting-started/bun.md
+++ b/docs/getting-started/bun.md
@@ -1,6 +1,6 @@
 # Bun
 
-[Bun](https://bun.com) is another JavaScript runtime. It's not Node.js or Deno. Bun includes a transcompiler, we can write the code with TypeScript.
+[Bun](https://bun.com) is another JavaScript runtime. It's not Node.js or Deno. Bun includes a transcompiler, so we can write the code in TypeScript or plain JavaScript.
 Hono also works on Bun.
 
 ## 1. Install Bun


### PR DESCRIPTION
The Bun getting-started page only shows TypeScript examples and says we write code "with TypeScript", which can read as TypeScript-only. Bun runs plain JavaScript too — this one-line tweak clarifies that for newcomers.

Closes #99.