### PR TITLE
docs(helpers): fix typos and header formatting

### DIFF
--- a/docs/helpers/adapter.md
+++ b/docs/helpers/adapter.md
@@ -11,7 +11,7 @@ import { env, getRuntimeKey } from 'hono/adapter'
 
 ## `env()`
 
-The `env()` function facilitates retrieving environment variables across different runtimes, extending beyond just Cloudflare Workers' Bindings. The value that can be retrieved with `env(c)` may be different for each runtimes.
+The `env()` function facilitates retrieving environment variables across different runtimes, extending beyond just Cloudflare Workers' Bindings. The value that can be retrieved with `env(c)` may be different for each runtime.
 
 ```ts
 import { env } from 'hono/adapter'
@@ -42,7 +42,7 @@ Supported Runtimes, Serverless Platforms and Cloud Services:
 - AWS Lambda
   - [Environment Variables on AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/samples-blank.html#samples-blank-architecture)
 - Lambda@Edge\
-  Environment Variables on Lambda are [not supported](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/add-origin-custom-headers.html) by Lambda@Edge, you need to use [Lamdba@Edge event](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html) as an alternative.
+  Environment Variables on Lambda are [not supported](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/add-origin-custom-headers.html) by Lambda@Edge, you need to use [Lambda@Edge event](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html) as an alternative.
 - Fastly Compute\
   On Fastly Compute, you can use the ConfigStore to manage user-defined data.
 - Netlify\

--- a/docs/helpers/cookie.md
+++ b/docs/helpers/cookie.md
@@ -168,7 +168,7 @@ const deletedCookie = deleteCookie(c, 'delicious_cookie')
 
 ## `__Secure-` and `__Host-` prefix
 
-The Cookie helper supports `__Secure-` and `__Host-` prefix for cookies names.
+The Cookie helper supports `__Secure-` and `__Host-` prefixes for cookie names.
 
 If you want to verify if the cookie name has a prefix, specify the prefix option.
 

--- a/docs/helpers/streaming.md
+++ b/docs/helpers/streaming.md
@@ -30,7 +30,7 @@ app.get('/stream', (c) => {
 
 ## `streamText()`
 
-It returns a streaming response with `Content-Type:text/plain`, `Transfer-Encoding:chunked`, and `X-Content-Type-Options:nosniff` headers.
+It returns a streaming response with `Content-Type: text/plain`, `Transfer-Encoding: chunked`, and `X-Content-Type-Options: nosniff` headers.
 
 ```ts
 app.get('/streamText', (c) => {
@@ -47,7 +47,7 @@ app.get('/streamText', (c) => {
 
 ::: warning
 
-If you are developing an application for Cloudflare Workers, a streaming may not work well on Wrangler. If so, add `Identity` for `Content-Encoding` header.
+If you are developing an application for Cloudflare Workers, streaming may not work well on Wrangler. If so, add `Identity` for `Content-Encoding` header.
 
 ```ts
 app.get('/streamText', (c) => {


### PR DESCRIPTION
Fixes small issues in helper documentation:

  - Corrects grammar in the Adapter helper docs
  - Fixes a typo in the Lambda@Edge link text
  - Corrects wording in the Cookie helper docs
  - Formats HTTP header examples in the Streaming helper docs
  - Improves wording in the Cloudflare Workers streaming warning

  Validation:

  - `bunx prettier --check docs/helpers/adapter.md docs/helpers/cookie.md docs/helpers/streaming.md`
  - `git diff --check`