### PR TITLE
docs: add aud validation documentation

### DIFF
--- a/docs/helpers/jwt.md
+++ b/docs/helpers/jwt.md
@@ -67,6 +67,7 @@ verify(
   secret: string,
   alg: 'HS256';
   issuer?: string | RegExp;
+  aud?: string | string[] | RegExp;
 ): Promise<any>;
 
 ```
@@ -102,6 +103,10 @@ The algorithm used for JWT signing or verification.
 #### <Badge type="info" text="optional" /> issuer: `string | RegExp`
 
 The expected issuer used for JWT verification.
+
+#### <Badge type="info" text="optional" /> aud: `string | string[] | RegExp`
+
+The expected audience used for JWT verification. If this is set, the token must include an `aud` claim and at least one audience value must match.
 
 ## `decode()`
 
@@ -144,6 +149,7 @@ When verifying a JWT token, the following payload validations are performed:
 - `nbf`: The token is checked to ensure it is not being used before a specified time.
 - `iat`: The token is checked to ensure it is not issued in the future.
 - `iss`: The token is checked to ensure it has been issued by a trusted issuer.
+- `aud`: The token is checked to ensure it is intended for an accepted audience when the `aud` verification parameter is set.
 
 Please ensure that your JWT payload includes these fields, as an object, if you intend to perform these checks during verification.
 
@@ -157,6 +163,8 @@ The module also defines custom error types to handle JWT-related errors.
 - `JwtTokenExpired`: Indicates that the token has expired.
 - `JwtTokenIssuedAt`: Indicates that the "iat" claim in the token is incorrect.
 - `JwtTokenIssuer`: Indicates that the "iss" claim in the token is incorrect.
+- `JwtPayloadRequiresAud`: Indicates that an `aud` claim is required when `aud` verification is configured.
+- `JwtTokenAudience`: Indicates that the token's `aud` claim does not match the expected audience.
 - `JwtTokenSignatureMismatched`: Indicates a signature mismatch in the token.
 
 ## Supported AlgorithmTypes

--- a/docs/middleware/builtin/jwk.md
+++ b/docs/middleware/builtin/jwk.md
@@ -167,6 +167,26 @@ The name of the header to look for the JWT token. The default is `Authorization`
 
 Configure claim validation behavior in addition to signature verification:
 
-- `iss`: expected issuer.
-- `aud`: expected audience.
-- `exp`, `nbf`, `iat`: enabled by default, can be disabled if needed.
+[Keep in sync with jwt.md]: #
+
+## VerifyOptions
+
+##### <Badge type="info" text="optional" /> VerifyOptions.iss: `string | RexExp`
+
+The expected issuer used for token verification. The `iss` claim will **not** be checked if this isn't set.
+
+##### <Badge type="info" text="optional" /> VerifyOptions.aud: `string | string[] | RegExp`
+
+The expected audience used for token verification. If this is set, the token must include an `aud` claim and at least one audience value must match.
+
+##### <Badge type="info" text="optional" /> VerifyOptions.nbf: `boolean`
+
+The `nbf` (not before) claim will be verified if present and this is set to `true`. The default is `true`.
+
+##### <Badge type="info" text="optional" /> VerifyOptions.iat: `boolean`
+
+The `iat` (issued at) claim will be verified if present and this is set to `true`. The default is `true`.
+
+##### <Badge type="info" text="optional" /> VerifyOptions.exp: `boolean`
+
+The `exp` (expiration time) claim will be verified if present and this is set to `true`. The default is `true`.

--- a/docs/middleware/builtin/jwk.md
+++ b/docs/middleware/builtin/jwk.md
@@ -169,24 +169,22 @@ Configure claim validation behavior in addition to signature verification:
 
 [Keep in sync with jwt.md]: #
 
-## VerifyOptions
-
-##### <Badge type="info" text="optional" /> VerifyOptions.iss: `string | RexExp`
+#### <Badge type="info" text="optional" /> VerifyOptions.iss: `string | RegExp`
 
 The expected issuer used for token verification. The `iss` claim will **not** be checked if this isn't set.
 
-##### <Badge type="info" text="optional" /> VerifyOptions.aud: `string | string[] | RegExp`
+#### <Badge type="info" text="optional" /> VerifyOptions.aud: `string | string[] | RegExp`
 
 The expected audience used for token verification. If this is set, the token must include an `aud` claim and at least one audience value must match.
 
-##### <Badge type="info" text="optional" /> VerifyOptions.nbf: `boolean`
+#### <Badge type="info" text="optional" /> VerifyOptions.nbf: `boolean`
 
 The `nbf` (not before) claim will be verified if present and this is set to `true`. The default is `true`.
 
-##### <Badge type="info" text="optional" /> VerifyOptions.iat: `boolean`
+#### <Badge type="info" text="optional" /> VerifyOptions.iat: `boolean`
 
 The `iat` (issued at) claim will be verified if present and this is set to `true`. The default is `true`.
 
-##### <Badge type="info" text="optional" /> VerifyOptions.exp: `boolean`
+#### <Badge type="info" text="optional" /> VerifyOptions.exp: `boolean`
 
 The `exp` (expiration time) claim will be verified if present and this is set to `true`. The default is `true`.

--- a/docs/middleware/builtin/jwt.md
+++ b/docs/middleware/builtin/jwt.md
@@ -48,7 +48,7 @@ app.use(
   jwt({
     secret: 'it-is-very-secret',
     alg: 'HS256',
-    verifyOptions: {
+    verification: {
       iss: 'my-trusted-issuer',
       aud: 'my-api',
     },
@@ -108,7 +108,7 @@ app.use(
 )
 ```
 
-### <Badge type="info" text="optional" /> verifyOptions: `VerifyOptions`
+### <Badge type="info" text="optional" /> verfication: `VerifyOptions`
 
 Options controlling verification of the token.
 

--- a/docs/middleware/builtin/jwt.md
+++ b/docs/middleware/builtin/jwt.md
@@ -112,22 +112,26 @@ app.use(
 
 Options controlling verification of the token.
 
-#### <Badge type="info" text="optional" /> verifyOptions.iss: `string | RexExp`
+[Keep in sync with jwk.md]: #
+
+## VerifyOptions
+
+##### <Badge type="info" text="optional" /> VerifyOptions.iss: `string | RexExp`
 
 The expected issuer used for token verification. The `iss` claim will **not** be checked if this isn't set.
 
-#### <Badge type="info" text="optional" /> verifyOptions.aud: `string | string[] | RegExp`
+##### <Badge type="info" text="optional" /> VerifyOptions.aud: `string | string[] | RegExp`
 
 The expected audience used for token verification. If this is set, the token must include an `aud` claim and at least one audience value must match.
 
-#### <Badge type="info" text="optional" /> verifyOptions.nbf: `boolean`
+##### <Badge type="info" text="optional" /> VerifyOptions.nbf: `boolean`
 
 The `nbf` (not before) claim will be verified if present and this is set to `true`. The default is `true`.
 
-#### <Badge type="info" text="optional" /> verifyOptions.iat: `boolean`
+##### <Badge type="info" text="optional" /> VerifyOptions.iat: `boolean`
 
 The `iat` (issued at) claim will be verified if present and this is set to `true`. The default is `true`.
 
-#### <Badge type="info" text="optional" /> verifyOptions.exp: `boolean`
+##### <Badge type="info" text="optional" /> VerifyOptions.exp: `boolean`
 
 The `exp` (expiration time) claim will be verified if present and this is set to `true`. The default is `true`.

--- a/docs/middleware/builtin/jwt.md
+++ b/docs/middleware/builtin/jwt.md
@@ -108,30 +108,28 @@ app.use(
 )
 ```
 
-### <Badge type="info" text="optional" /> verfication: `VerifyOptions`
+### <Badge type="info" text="optional" /> verification: `VerifyOptions`
 
 Options controlling verification of the token.
 
 [Keep in sync with jwk.md]: #
 
-## VerifyOptions
-
-##### <Badge type="info" text="optional" /> VerifyOptions.iss: `string | RexExp`
+#### <Badge type="info" text="optional" /> VerifyOptions.iss: `string | RegExp`
 
 The expected issuer used for token verification. The `iss` claim will **not** be checked if this isn't set.
 
-##### <Badge type="info" text="optional" /> VerifyOptions.aud: `string | string[] | RegExp`
+#### <Badge type="info" text="optional" /> VerifyOptions.aud: `string | string[] | RegExp`
 
 The expected audience used for token verification. If this is set, the token must include an `aud` claim and at least one audience value must match.
 
-##### <Badge type="info" text="optional" /> VerifyOptions.nbf: `boolean`
+#### <Badge type="info" text="optional" /> VerifyOptions.nbf: `boolean`
 
 The `nbf` (not before) claim will be verified if present and this is set to `true`. The default is `true`.
 
-##### <Badge type="info" text="optional" /> VerifyOptions.iat: `boolean`
+#### <Badge type="info" text="optional" /> VerifyOptions.iat: `boolean`
 
 The `iat` (issued at) claim will be verified if present and this is set to `true`. The default is `true`.
 
-##### <Badge type="info" text="optional" /> VerifyOptions.exp: `boolean`
+#### <Badge type="info" text="optional" /> VerifyOptions.exp: `boolean`
 
 The `exp` (expiration time) claim will be verified if present and this is set to `true`. The default is `true`.

--- a/docs/middleware/builtin/jwt.md
+++ b/docs/middleware/builtin/jwt.md
@@ -48,7 +48,10 @@ app.use(
   jwt({
     secret: 'it-is-very-secret',
     alg: 'HS256',
-    issuer: 'my-trusted-issuer',
+    verifyOptions: {
+      iss: 'my-trusted-issuer',
+      aud: 'my-api',
+    },
   })
 )
 
@@ -112,6 +115,10 @@ Options controlling verification of the token.
 #### <Badge type="info" text="optional" /> verifyOptions.iss: `string | RexExp`
 
 The expected issuer used for token verification. The `iss` claim will **not** be checked if this isn't set.
+
+#### <Badge type="info" text="optional" /> verifyOptions.aud: `string | string[] | RegExp`
+
+The expected audience used for token verification. If this is set, the token must include an `aud` claim and at least one audience value must match.
 
 #### <Badge type="info" text="optional" /> verifyOptions.nbf: `boolean`
 


### PR DESCRIPTION
This documents the `aud` claim validation support that was added.