### PR TITLE
fix: use dark text on brand buttons for WCAG AA contrast

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -99,6 +99,10 @@
   --vp-c-brand-3: var(--vp-c-orange-lighter);
   --vp-c-brand-soft: var(--vp-c-orange-soft);
   --vp-code-color: var(--vp-c-text-light-2);
+
+  --vp-button-brand-text: var(--vp-c-black);
+  --vp-button-brand-hover-text: var(--vp-c-black);
+  --vp-button-brand-active-text: var(--vp-c-black);
 }
 
 /**


### PR DESCRIPTION
## Summary

The hero **"Get Started"** button (and other `theme: brand` buttons) renders white text over the orange brand background. At rest this is only ~2.1:1 contrast, which fails [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) (4.5:1 required for normal text).

This switches the brand button **text** color to `--vp-c-black` and leaves the orange brand backgrounds untouched. Contrast vs. text color before/after:

| State  | Background | Before (white) | After (black) |
| ------ | ---------- | -------------- | ------------- |
| Rest   | `#ff9c24`  | 2.09:1 ❌      | 10.03:1 ✅    |
| Hover  | `#ff861d`  | 2.42:1 ❌      | 8.68:1 ✅     |
| Active | `#e36002`  | 3.54:1 ❌      | 5.94:1 ✅     |

Scoped to the existing `custom.css` variable overrides, consistent with how prior color/contrast fixes were handled in this repo.

## Before / After

| Before | After |
| ------ | ----- |
| <img width="242" height="237" alt="Captura de pantalla 2026-06-23 162302" src="https://github.com/user-attachments/assets/13d0d407-bad9-4494-a755-8039b1d23110" /> | <img width="204" height="231" alt="image" src="https://github.com/user-attachments/assets/240c6687-babb-4c94-a395-0e05c1e4199d" /> |

## Verification

- `bun install --frozen-lockfile`
- `bun run format`
- `bun run build`
