### PR TITLE
docs(cloudflare-workers): document wrangler types --env-interface for auto-generated bindings

### DIFF
--- a/docs/getting-started/cloudflare-workers.md
+++ b/docs/getting-started/cloudflare-workers.md
@@ -241,6 +241,26 @@ app.put('/upload/:key', async (c, next) => {
 })
 ```
 
+### Generating Bindings Types Automatically
+
+Instead of defining bindings types by hand, you can auto-generate them from your `wrangler.toml` using the `wrangler types` command. Use the `--env-interface` flag to avoid a naming collision with Hono's built-in `Env` type:
+
+```sh
+wrangler types --env-interface CloudflareBindings
+```
+
+This generates a `worker-configuration.d.ts` file with the interface name you specify. Then pass it to Hono:
+
+```ts
+const app = new Hono<{ Bindings: CloudflareBindings }>()
+
+app.put('/upload/:key', async (c, next) => {
+  const key = c.req.param('key')
+  await c.env.MY_BUCKET.put(key, c.req.body)
+  return c.text(`Put ${key} successfully!`)
+})
+```
+
 ## Using Variables in Middleware
 
 This is the only case for Module Worker mode.


### PR DESCRIPTION
## Summary

Fixes #842

The Cloudflare Workers getting-started guide only showed manual type definitions for bindings. This adds a subsection documenting how to use `wrangler types --env-interface CloudflareBindings` to:

1. **Auto-generate** bindings types from `wrangler.toml` instead of writing them by hand
2. **Avoid** the naming collision between Hono's built-in `Env` type and the default `Env` interface generated by `wrangler types`

## Changes

- `docs/getting-started/cloudflare-workers.md`: Added "Generating Bindings Types Automatically" subsection under the Bindings section

## Test plan
- [ ] Verify the docs render correctly on the website
- [ ] Confirm the `wrangler types --env-interface` command works as documented