### PR TITLE
docs(middleware): add StitchAPI to third-party middleware list

### DIFF
--- a/docs/middleware/third-party.md
+++ b/docs/middleware/third-party.md
@@ -94,5 +94,6 @@ Most of this middleware leverages external libraries.
 - [MCP](https://github.com/honojs/middleware/tree/main/packages/mcp)
 - [RONIN (Database)](https://github.com/ronin-co/hono-client)
 - [Session](https://github.com/honojs/middleware/tree/main/packages/session)
+- [StitchAPI (Typed, resilient API calls + SSE)](https://github.com/rejifald/StitchAPI/tree/main/packages/hono)
 - [tsyringe](https://github.com/honojs/middleware/tree/main/packages/tsyringe)
 - [User Agent based Blocker](https://github.com/honojs/middleware/tree/main/packages/ua-blocker)


### PR DESCRIPTION
Adds StitchAPI to the **Utilities** section of the third-party middleware list.

[`@stitchapi/hono`](https://github.com/rejifald/StitchAPI/tree/main/packages/hono) is Hono middleware for [StitchAPI](https://stitchapi.dev): it puts a per-request `seam` on the context (`c.get('stitch')`) — a principal-bound handle for typed, validated, resilient outbound API calls — plus an SSE streaming helper (`streamStitchSse`) and a Stitch-error → HTTP mapper. Every import is from `hono` or `stitchapi` (no `node:*`), so it runs on Node, Cloudflare Workers, Deno, Bun and Vercel Edge.

Placed alphabetically within Utilities (between Session and tsyringe).
