### PR TITLE
docs: mention Standard Schema validators in RPC guide

### DIFF
--- a/docs/guides/rpc.md
+++ b/docs/guides/rpc.md
@@ -36,6 +36,9 @@ const route = app.post(
 )
 ```
 
+> [!TIP]
+> The [Standard Schema Validator](https://github.com/honojs/middleware/tree/main/packages/standard-validator) works as well, so you can use any Standard Schema library such as Valibot.
+
 Then, export the type to share the API spec with the Client.
 
 ```ts


### PR DESCRIPTION
The RPC guide only mentions the Zod Validator. This adds a tip that the Standard Schema Validator works as well, so users can use any Standard Schema library such as Valibot. I'm the author of Valibot.