### PR TITLE
docs: document mount replaceRequest option

### DIFF
--- a/docs/api/hono.md
+++ b/docs/api/hono.md
@@ -180,7 +180,19 @@ const app = new Hono()
 app.mount('/itty-router', ittyRouter.handle)
 ```
 
-By default, `mount()` passes a new `Request` with the mount path removed from its URL. Set `replaceRequest` to `false` to pass the original `Request` unchanged.
+By default, `mount()` passes a new `Request` with the mount path removed from its URL. Provide a `replaceRequest` function to control which `Request` is passed to the mounted application:
+
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+const handler = (request: Request) => new Response(request.url)
+// ---cut---
+app.mount('/app', handler, {
+  replaceRequest: (originalRequest) => originalRequest,
+})
+```
+
+To pass the original `Request` unchanged, set `replaceRequest` to `false` as a shorthand for the function above:
 
 ```ts twoslash
 import { Hono } from 'hono'

--- a/docs/api/hono.md
+++ b/docs/api/hono.md
@@ -24,7 +24,7 @@ An instance of `Hono` has the following methods.
 - app.**basePath**(path)
 - app.**notFound**(handler)
 - app.**onError**(err, handler)
-- app.**mount**(path, anotherApp)
+- app.**mount**(path, anotherApp, \[options\])
 - app.**fire**()
 - app.**fetch**(request, env, event)
 - app.**request**(path, options)
@@ -178,6 +178,18 @@ const app = new Hono()
 
 // Mount!
 app.mount('/itty-router', ittyRouter.handle)
+```
+
+By default, `mount()` passes a new `Request` with the mount path removed from its URL. Set `replaceRequest` to `false` to pass the original `Request` unchanged.
+
+```ts twoslash
+import { Hono } from 'hono'
+const app = new Hono()
+const handler = (request: Request) => new Response(request.url)
+// ---cut---
+app.mount('/app', handler, {
+  replaceRequest: false,
+})
 ```
 
 ## strict mode


### PR DESCRIPTION
The `app.mount` options are undocumented, not just this one. Since there isn't an "Options" subsection on this page, I kept it simple in the PR. Feel free to adjust it if needed.