### PR TITLE
docs(rpc): document the promise chain inference limitation

### DIFF
--- a/docs/guides/rpc.md
+++ b/docs/guides/rpc.md
@@ -852,8 +852,7 @@ This way, `tsserver` doesn't need to instantiate types for all routes at once.
 
 ### Handlers that return a promise chain
 
-A handler that returns a `.then()` chain directly loses its response type, so
-the client infers `unknown`:
+A handler that returns a `.then()` chain directly loses its response type, so the client infers `unknown`:
 
 ```ts
 const app = new Hono().get('/', (c) =>
@@ -865,13 +864,7 @@ const res = await client.index.$get()
 const data = await res.json() // unknown
 ```
 
-Inside the callback, the type of `c` depends on the handler's return type,
-which is what the callback is being used to infer. TypeScript cannot resolve
-that cycle, so it falls back to the constraint of the return type: a union of
-every shape a handler may return. The route schema is built from that union,
-and the response type is lost.
-
-Await the promise instead of chaining, and the response type is preserved:
+This is a TypeScript inference limitation — the response type cannot be inferred through a `.then()` chain. Use `async`/`await` instead:
 
 ```ts
 const app = new Hono().get('/', async (c) => {
@@ -884,7 +877,7 @@ const res = await client.index.$get()
 const data = await res.json() // { hello: string }
 ```
 
-Annotating `then()` works as well, though it is more verbose:
+If you cannot avoid the chain, annotating `then()` also works:
 
 ```ts
 import type { TypedResponse } from 'hono/types'

--- a/docs/guides/rpc.md
+++ b/docs/guides/rpc.md
@@ -849,3 +849,49 @@ const booksClient = hc<typeof booksApp>('/books')
 ```
 
 This way, `tsserver` doesn't need to instantiate types for all routes at once.
+
+### Handlers that return a promise chain
+
+A handler that returns a `.then()` chain directly loses its response type, so
+the client infers `unknown`:
+
+```ts
+const app = new Hono().get('/', (c) =>
+  Promise.resolve({ hello: 'world' }).then((d) => c.json(d))
+)
+
+const client = hc<typeof app>('')
+const res = await client.index.$get()
+const data = await res.json() // unknown
+```
+
+Inside the callback, the type of `c` depends on the handler's return type,
+which is what the callback is being used to infer. TypeScript cannot resolve
+that cycle, so it falls back to the constraint of the return type: a union of
+every shape a handler may return. The route schema is built from that union,
+and the response type is lost.
+
+Await the promise instead of chaining, and the response type is preserved:
+
+```ts
+const app = new Hono().get('/', async (c) => {
+  const d = await Promise.resolve({ hello: 'world' })
+  return c.json(d)
+})
+
+const client = hc<typeof app>('')
+const res = await client.index.$get()
+const data = await res.json() // { hello: string }
+```
+
+Annotating `then()` works as well, though it is more verbose:
+
+```ts
+import type { TypedResponse } from 'hono/types'
+
+const app = new Hono().get('/', (c) =>
+  Promise.resolve({ hello: 'world' }).then<
+    TypedResponse<{ hello: string }, 200, 'json'>
+  >((d) => c.json(d, 200))
+)
+```


### PR DESCRIPTION
Documents the RPC limitation reported in honojs/hono#4765, where a handler that
returns a `.then()` chain directly infers `unknown` on the client.

@yusukebe [suggested](https://github.com/honojs/hono/issues/4765#issuecomment-3573372800)
leaving the behaviour as-is and documenting the limitation, so this adds it
under "Known issues" in the RPC guide, with the reason it happens and the two
ways around it.

Each snippet was checked against `hono` `main`:

- the `.then()` chain infers `unknown`
- awaiting the promise and returning `c.json(d)` infers `{ hello: string }`
- annotating `then<TypedResponse<{ hello: string }, 200, 'json'>>` infers `{ hello: string }`

`TypedResponse` is used for the annotation because `JSONRespondReturn` is not
exported from the package.
