### PR TITLE
docs: update InferDI example for v6

### DIFF
--- a/examples/inferdi.md
+++ b/examples/inferdi.md
@@ -39,7 +39,7 @@ export interface RequestContext {
 }
 
 const config = {
-  dsn: 'postgres://localhost/app'
+  dsn: 'postgres://localhost/app',
 } satisfies { readonly dsn: string }
 
 export const root = new Container()
@@ -63,7 +63,8 @@ input. `users` is scoped because a singleton cannot depend on request-scoped dat
 Use a function to create the concrete scope required by the application:
 
 ```ts
-const openRequestScope = (request: RequestContext) => root.createScope({ request })
+const openRequestScope = (request: RequestContext) =>
+  root.createScope({ request })
 
 type RequestScope = ReturnType<typeof openRequestScope>
 ```
@@ -74,10 +75,7 @@ type RequestScope = ReturnType<typeof openRequestScope>
 
 ```ts
 import { Hono } from 'hono'
-import {
-  inferdiHono,
-  type InferdiHonoScopeEnv,
-} from '@inferdi/hono'
+import { inferdiHono, type InferdiHonoScopeEnv } from '@inferdi/hono'
 
 type AppEnv = InferdiHonoScopeEnv<RequestScope>
 
@@ -86,14 +84,15 @@ const app = new Hono<AppEnv>()
 const createRequestScope = (userId: string | undefined) =>
   openRequestScope({
     requestId: crypto.randomUUID(),
-    userId
+    userId,
   })
 
 app.use(
   '*',
   inferdiHono({
     container: root,
-    createScope: (_root, c) => createRequestScope(c.req.header('x-user-id'))
+    createScope: (_root, c) =>
+      createRequestScope(c.req.header('x-user-id')),
   })
 )
 ```
@@ -151,7 +150,8 @@ customKeyApp.use(
   inferdiHono({
     container: root,
     key: 'container',
-    createScope: (_root, c) => createRequestScope(c.req.header('x-user-id'))
+    createScope: (_root, c) =>
+      createRequestScope(c.req.header('x-user-id')),
   })
 )
 
@@ -166,7 +166,7 @@ customKeyApp.get('/users/:id', async (c) => {
 `inferdiHono` accepts these options:
 
 | Option           | Default              | Description                                                                     |
-|------------------|----------------------|---------------------------------------------------------------------------------|
+| ---------------- | -------------------- | ------------------------------------------------------------------------------- |
 | `container`      | Required             | Root container. The middleware never disposes it.                               |
 | `key`            | `'di'`               | Context variable used by `c.var[key]` and `c.get(key)`.                         |
 | `createScope`    | `root.createScope()` | Creates the request scope. Use it to pass typed inputs from Hono. May be async. |

--- a/examples/inferdi.md
+++ b/examples/inferdi.md
@@ -1,145 +1,212 @@
 # InferDI
 
-[InferDI](https://github.com/inferdi/inferdi) is a zero-dependency, decorator-free, strongly typed dependency injection container for TypeScript. The [`@inferdi/hono`](https://www.npmjs.com/package/@inferdi/hono) middleware wires it into Hono's request pipeline: it creates one DI scope per request, exposes it on the context as `c.var.di`, and disposes it after the response completes — no decorators, reflection, or route scanning.
+[InferDI](https://github.com/inferdi/inferdi) is a dependency
+injection container for TypeScript. It has no decorators, reflection,
+or runtime dependencies. The
+[`@inferdi/hono`](https://www.npmjs.com/package/@inferdi/hono)
+middleware creates a request scope for each middleware invocation, exposes it as
+`c.var.di`, and disposes it after the route pipeline finishes.
 
-The graph _is_ the type: a misordered dependency, a missing key, or a request-scoped value leaking into a singleton are all compile errors, not runtime surprises.
+The container carries its dependency graph in its type. TypeScript
+reports missing or misordered dependencies and invalid lifetime
+relationships.
 
-## 🛠️ Installation
+## Installation
 
 ```bash
 npm install @inferdi/inferdi @inferdi/hono
 ```
 
 > [!NOTE]
-> InferDI ships on both npm and JSR. On Deno install it with `deno add jsr:@inferdi/inferdi jsr:@inferdi/hono npm:hono`.
+> InferDI is also available on JSR. With Deno, run
+> `deno add jsr:@inferdi/inferdi jsr:@inferdi/hono npm:hono`.
 
-## 🚀 Getting Started
+## Getting started
 
-### 1. Build a container
+### 1. Build the container
 
-Register your services on a root `Container`. Dependencies are passed as a tuple of keys and type-checked positionally against the constructor — a wrong order or type is a compile error. Each registration declares a lifetime: `singleton` (default, one instance per container), `scoped` (one per request), or `transient` (new on every resolve).
+Request data belongs at the HTTP boundary. Define a small application
+type instead of putting Hono's `Context` in the dependency graph.
 
 ```ts
 // container.ts
 import { Container } from '@inferdi/inferdi'
+import { connectDatabase, UserService } from './services'
 
-export function buildRootContainer() {
-  return (
-    new Container()
-      .registerClass('logger', Logger, [])
-      // `request` is scoped: a fresh instance per request scope.
-      .registerClass('request', RequestContext, [], 'scoped')
-      // `users` is scoped too — it depends on the scoped `request`.
-      .registerClass(
-        'users',
-        UserService,
-        ['logger', 'request'],
-        'scoped'
-      )
-  )
+export interface RequestContext {
+  readonly requestId: string
+  readonly userId: string | undefined
 }
+
+const config = {
+  dsn: 'postgres://localhost/app'
+} satisfies { readonly dsn: string }
+
+export const root = new Container()
+  .registerValue('config', config)
+  .declareScopeInputs<{ request: RequestContext }>()
+  .registerAsyncFactory(
+    'db',
+    (config: typeof config) => connectDatabase(config.dsn),
+    ['config']
+  )
+  .registerClass('users', UserService, ['db', 'request'], 'scoped')
 ```
 
-> [!NOTE]
-> A `singleton` cannot depend on a `scoped` or `transient` service — that would leak a short-lived value into a long-lived one, and InferDI rejects it at compile time. Keep request-bound services `scoped`.
+`declareScopeInputs()` adds a type-only slot to the graph. It does not
+register a value. Because `users` depends on `request`, InferDI does
+not allow that service to be resolved until a scope provides the
+input. `users` is scoped because a singleton cannot depend on request-scoped data.
 
-### 2. Add the middleware
+### 2. Create the request scope
 
-`inferdiHono` creates a request scope before your handlers run and disposes it afterwards. `InferdiHonoEnv<typeof root>` types `c.var.di` as your concrete scope, so `.get(key)` stays fully typed.
+Use a function to create the concrete scope required by the application:
+
+```ts
+const openRequestScope = (request: RequestContext) => root.createScope({ request })
+
+type RequestScope = ReturnType<typeof openRequestScope>
+```
+
+### 3. Add the middleware
+
+`InferdiHonoScopeEnv` exposes the concrete, ready `RequestScope` through Hono's context variables.
 
 ```ts
 import { Hono } from 'hono'
-import { inferdiHono, type InferdiHonoEnv } from '@inferdi/hono'
-import { buildRootContainer } from './container'
+import {
+  inferdiHono,
+  type InferdiHonoScopeEnv,
+} from '@inferdi/hono'
 
-const root = buildRootContainer()
-const app = new Hono<InferdiHonoEnv<typeof root>>()
+type AppEnv = InferdiHonoScopeEnv<RequestScope>
 
-app.use('*', inferdiHono({ container: root }))
+const app = new Hono<AppEnv>()
 
-export default app
-```
+const createRequestScope = (userId: string | undefined) =>
+  openRequestScope({
+    requestId: crypto.randomUUID(),
+    userId
+  })
 
-### 3. Hydrate the request scope
-
-Use `setupScope` to fill request-scoped services with per-request data (request id, authenticated user, …) before any handler sees the scope. It runs once per request and may be async.
-
-```ts
 app.use(
   '*',
   inferdiHono({
     container: root,
-    setupScope: (scope, c) => {
-      const request = scope.get('request')
-      request.requestId = crypto.randomUUID()
-      request.userId = c.req.header('x-user-id')
-    },
+    createScope: (_root, c) => createRequestScope(c.req.header('x-user-id'))
   })
 )
 ```
 
-### 4. Resolve services in handlers
+`InferdiHonoEnv<typeof root>` remains useful when the middleware uses
+the type returned by the root's zero-argument `createScope()`. A
+custom scope factory can return a more specific type, as it does here,
+so this example uses `InferdiHonoScopeEnv<RequestScope>`.
 
-Resolve any registered service from the request scope with `c.var.di.get(key)`. The returned value is fully typed, and scoped services share one instance for the whole request.
+### 4. Resolve services
+
+Use `get()` for ready synchronous keys and `getAsync()` for
+declarative async keys. The `request` input is synchronous, while
+`users` is async because it depends on `db`.
 
 ```ts
 app.get('/users/:id', async (c) => {
-  const user = await c.var.di.get('users').profile(c.req.param('id'))
-  return c.json(user)
+  const request = c.var.di.get('request') // RequestContext
+  const users = await c.var.di.getAsync('users') // UserService
+  const user = await users.profile(c.req.param('id'))
+
+  return c.json({ requestId: request.requestId, user })
+})
+
+export default app
+```
+
+`c.get('di')` is equivalent to `c.var.di` and has the same type.
+
+## Async dependencies
+
+`registerAsyncFactory()` stores the final `Database` type in the
+graph, not `Promise<Database>`. Its async status propagates to
+`UserService`, so both services are resolved with `getAsync()`.
+Although `getAsync()` also accepts ready synchronous keys, use `get()`
+for ordinary sync services.
+
+A `registerFactory()` callback that returns a Promise has different
+semantics. The Promise itself is the service value, remains a sync
+graph entry, and is resolved with `get()`.
+
+## Custom context key
+
+Pass `key` to expose the same scope under another Hono context
+variable. The custom scope factory must still provide the declared
+request input.
+
+```ts
+type CustomEnv = InferdiHonoScopeEnv<RequestScope, 'container'>
+
+const customKeyApp = new Hono<CustomEnv>()
+
+customKeyApp.use(
+  '*',
+  inferdiHono({
+    container: root,
+    key: 'container',
+    createScope: (_root, c) => createRequestScope(c.req.header('x-user-id'))
+  })
+)
+
+customKeyApp.get('/users/:id', async (c) => {
+  const users = await c.var.container.getAsync('users')
+  return c.json(await users.profile(c.req.param('id')))
 })
 ```
 
-`c.get('di')` is equivalent to `c.var.di`. To use a different context key, pass `key` and reflect it in the env type:
+## Options
+
+`inferdiHono` accepts these options:
+
+| Option           | Default              | Description                                                                     |
+|------------------|----------------------|---------------------------------------------------------------------------------|
+| `container`      | Required             | Root container. The middleware never disposes it.                               |
+| `key`            | `'di'`               | Context variable used by `c.var[key]` and `c.get(key)`.                         |
+| `createScope`    | `root.createScope()` | Creates the request scope. Use it to pass typed inputs from Hono. May be async. |
+| `setupScope`     | None                 | Runs after scope creation and before route handlers. May be async.              |
+| `disposeScope`   | `scope.dispose()`    | Overrides request-scope disposal. May be async.                                 |
+| `autoDispose`    | `true`               | Set to `false`, or return `false`, when application code owns disposal.         |
+| `onDisposeError` | `console.error`      | Handles request-scope cleanup failures.                                         |
+
+## Streaming
+
+Hono's `stream()`, `streamText()`, and `streamSSE()` can return a
+`Response` before their callbacks finish. Call `skipInferdiDispose()`
+before returning the response, then dispose the scope when the stream
+ends.
 
 ```ts
-type AppEnv = InferdiHonoEnv<typeof root, 'container'>
-
-const app = new Hono<AppEnv>()
-app.use('*', inferdiHono({ container: root, key: 'container' }))
-
-app.get('/users/:id', (c) =>
-  c.json(c.var.container.get('users').profile(c.req.param('id')))
-)
-```
-
-## ⚙️ Options
-
-`inferdiHono` accepts the following options:
-
-| Option           | Default              | Description                                                               |
-| ---------------- | -------------------- | ------------------------------------------------------------------------- |
-| `container`      | —                    | **Required.** The root container. The middleware never disposes the root. |
-| `key`            | `'di'`               | Context variable key used for `c.var[key]` / `c.get(key)`.                |
-| `createScope`    | `root.createScope()` | Overrides how the request scope is created. May be async.                 |
-| `setupScope`     | —                    | Hydrates the scope before handlers run. May be async.                     |
-| `disposeScope`   | `scope.dispose()`    | Overrides request-scope disposal. May be async.                           |
-| `autoDispose`    | `true`               | Set to `false` (or return `false`) when application code owns disposal.   |
-| `onDisposeError` | `console.error`      | Sink for post-response disposal failures.                                 |
-
-## 🌊 Streaming
-
-A streaming response returns before the stream callback finishes, so disable auto-disposal with `skipInferdiDispose(c)` and dispose the scope yourself when the stream ends.
-
-```ts
-import { stream } from 'hono/streaming'
+import { streamText } from 'hono/streaming'
 import { skipInferdiDispose } from '@inferdi/hono'
 
-app.get('/events', (c) => {
+app.get('/users/:id/export', (c) => {
   skipInferdiDispose(c)
-  const scope = c.var.di
-  const events = scope.get('events')
 
-  return stream(c, async (s) => {
+  const scope = c.var.di
+  const id = c.req.param('id')
+
+  return streamText(c, async (stream) => {
     try {
-      for await (const event of events.subscribe()) {
-        await s.write(`data: ${JSON.stringify(event)}\n\n`)
-      }
+      const users = await scope.getAsync('users')
+      const user = await users.profile(id)
+      await stream.write(JSON.stringify(user) ?? 'null')
     } finally {
       await scope.dispose()
     }
   })
 })
 ```
+
+`skipInferdiDispose()` suppresses automatic cleanup only for a
+successful response. If the route fails before returning the response,
+the middleware still disposes the scope.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Updates the InferDI example to match InferDI 6 and the current Hono adapter API.

The guide now uses typed scope inputs for request data, a concrete request scope with `InferdiHonoScopeEnv`, and `createScope` to pass values from the Hono request boundary. It also documents declarative async dependencies, `getAsync()`, custom
context keys, and streaming cleanup.

## Verification

- Ran `git diff --check`
- Verified the documented APIs against InferDI 6.0.1
- Tested the scope creation, async resolution, and disposal flow