### PR TITLE
docs: clarify why graceful shutdown is needed on Node.js but not Bun, Deno and others.

### DIFF
--- a/docs/getting-started/nodejs.md
+++ b/docs/getting-started/nodejs.md
@@ -83,8 +83,6 @@ app.get('/', (c) => c.text('Hello Node.js!'))
 serve(app)
 ```
 
-Node.js's native `http` module predates the Fetch API, so `@hono/node-server` wraps it and hands you the resulting server instance to manage yourself. This is why graceful shutdown needs to be handled explicitly here, unlike on Bun or Deno, where the runtime implements the Fetch API natively and owns the server lifecycle.
-
 If you want to gracefully shut down the server, write it like this:
 
 ```ts
@@ -105,6 +103,10 @@ process.on('SIGTERM', () => {
   })
 })
 ```
+
+::: info
+On Node.js, `serve()` wraps the `node:http` module and returns the underlying server instance, so closing it is up to you. Bun and Deno serve Fetch handlers natively and manage the server themselves, which is why their guides don't include this step.
+:::
 
 ## 3. Run
 

--- a/docs/getting-started/nodejs.md
+++ b/docs/getting-started/nodejs.md
@@ -83,6 +83,8 @@ app.get('/', (c) => c.text('Hello Node.js!'))
 serve(app)
 ```
 
+Node.js's native `http` module predates the Fetch API, so `@hono/node-server` wraps it and hands you the resulting server instance to manage yourself. This is why graceful shutdown needs to be handled explicitly here, unlike on Bun or Deno, where the runtime implements the Fetch API natively and owns the server lifecycle.
+
 If you want to gracefully shut down the server, write it like this:
 
 ```ts


### PR DESCRIPTION
## Summary

The Node.js getting-started guide shows how to gracefully shut down the server, but doesn't say *why* this is only needed there and not on the Bun or Deno pages. This adds a short, two-sentence note explaining the reason:

- Node.js's native `http` module predates the Fetch API, so `@hono/node-server` wraps it and exposes the resulting server instance for you to manage.
- Bun and Deno implement the Fetch API natively and own the server lifecycle themselves, so there's no separate server instance for Hono to hand back — which is why those pages don't cover graceful shutdown.

## Test plan

- [x] Docs-only change, no code affected.
- [x] Verified the note renders correctly in the existing Markdown/VitePress structure (plain paragraph, no new components).

Opening as a draft while I get feedback on wording/placement.