### PR TITLE
docs(third-party): add Shopify Auth middleware

### DIFF
--- a/docs/middleware/third-party.md
+++ b/docs/middleware/third-party.md
@@ -15,6 +15,7 @@ Most of this middleware leverages external libraries.
 - [Verify RSA JWT (JWKS)](https://github.com/wataruoguchi/verify-rsa-jwt-cloudflare-worker)
 - [SSOJet Auth](https://github.com/ssojet/ssojet-hono)
 - [Stytch Auth](https://github.com/honojs/middleware/tree/main/packages/stytch-auth)
+- [Shopify Auth](https://github.com/besart-k/hono-shopify-auth)
 
 ### Validators
 


### PR DESCRIPTION
Adds hono-shopify-auth to the Authentication section of third-party middleware.

It's a zero-dependency Shopify middleware for embedded apps and webhooks — session token (App Bridge JWT) verification, token exchange with refresh handling, and webhook HMAC validation. Works on Workers, Deno, Bun, and Node.

Check the PR for more context honojs/middleware#2090.

npm: https://www.npmjs.com/package/hono-shopify-auth
repo: https://github.com/besart-k/hono-shopify-auth