### PR TITLE
docs: add mcp-use to Hono integrations

### DIFF
--- a/docs/middleware/third-party.md
+++ b/docs/middleware/third-party.md
@@ -60,6 +60,7 @@ Most of this middleware leverages external libraries.
 - [GraphQL Server](https://github.com/honojs/middleware/tree/main/packages/graphql-server)
 - [oRPC](https://orpc.dev/docs/adapters/hono)
 - [tRPC Server](https://github.com/honojs/middleware/tree/main/packages/trpc-server)
+- [mcp-use (MCP Server)](https://github.com/mcp-use/mcp-use)
 
 ### Transpiler
 


### PR DESCRIPTION
Adds mcp-use to Hono's `Server / Adapter` integrations.

mcp-use lets Hono apps expose MCP tools and interactive MCP App views through
the Fetch-compatible `MCPServer.fetch()` handler.

```ts
// index.ts
import { Hono } from "hono";
import { MCPServer } from "mcp-use";
import { z } from "zod";

const mcp = new MCPServer({
  name: "hono-mcp-example",
  version: "1.0.0",
});

mcp.tool(
  {
    name: "greet",
    description: "Greet a person",
    inputSchema: z.object({ name: z.string() }),
    outputSchema: z.object({ message: z.string() }),
    view: { name: "greeting" },
  },
  async ({ name }) => ({
    content: [{ type: "text", text: `Hello, ${name}!` }],
    structuredContent: { message: `Hello, ${name}!` },
  }),
);

const app = new Hono();
app.all("/mcp/*", (c) => mcp.fetch(c.req.raw));

export default app;
```

The tool's view is defined at `views/greeting/view.tsx`:

```tsx
import { useToolContext } from "mcp-use/react";

export default function GreetingView() {
  const view = useToolContext<"greet">();

  if (view.status !== "ready") return <p>Loading...</p>;

  return <h2>{view.toolOutput.message}</h2>;
}
```

See the [Hono integration example](https://docs.mcp-use.com/typescript/server/deployment/hono)
and [MCP Apps documentation](https://docs.mcp-use.com/typescript/mcp-apps).

I added the link to the repo (10.5k stars)  which uses hono underneath but maybe the link to the integration doc page might be more relevant